### PR TITLE
Decouple signal processing from the core strategy engine

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,79 @@
+"""Root conftest: mock pandas_ta when it's not installable (Python < 3.12)."""
+
+import sys
+import types
+
+try:
+    import pandas_ta  # noqa: F401
+except (ImportError, ModuleNotFoundError, Exception):
+    import numpy as np
+    import pandas as pd
+
+    pta = types.ModuleType("pandas_ta")
+    pta.version = "0.0.0-mock"
+
+    def _rsi(prices, length=14):
+        delta = prices.diff()
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        avg_gain = gain.ewm(alpha=1 / length, min_periods=length).mean()
+        avg_loss = loss.ewm(alpha=1 / length, min_periods=length).mean()
+        rs = avg_gain / avg_loss
+        result = 100 - (100 / (1 + rs))
+        result.iloc[:length] = float("nan")
+        return result
+
+    def _sma(prices, length=20):
+        return prices.rolling(length).mean()
+
+    def _ema(prices, length=20):
+        if len(prices) < length:
+            return None
+        return prices.ewm(span=length, adjust=False).mean()
+
+    def _macd(prices, fast=12, slow=26, signal=9):
+        if len(prices) < slow + signal:
+            return None
+        fast_ema = prices.ewm(span=fast, adjust=False).mean()
+        slow_ema = prices.ewm(span=slow, adjust=False).mean()
+        macd_line = fast_ema - slow_ema
+        signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+        histogram = macd_line - signal_line
+        return pd.DataFrame(
+            {
+                f"MACD_{fast}_{slow}_{signal}": macd_line,
+                f"MACDs_{fast}_{slow}_{signal}": signal_line,
+                f"MACDh_{fast}_{slow}_{signal}": histogram,
+            },
+            index=prices.index,
+        )
+
+    def _bbands(prices, length=20, std=2.0):
+        mid = prices.rolling(length).mean()
+        std_dev = prices.rolling(length).std()
+        upper = mid + std * std_dev
+        lower = mid - std * std_dev
+        return pd.DataFrame(
+            {
+                f"BBU_{length}_{std}_{std}": upper,
+                f"BBM_{length}_{std}_{std}": mid,
+                f"BBL_{length}_{std}_{std}": lower,
+            },
+            index=prices.index,
+        )
+
+    def _atr(high, low, close, length=14):
+        tr1 = high - low
+        tr2 = abs(high - close.shift(1))
+        tr3 = abs(low - close.shift(1))
+        tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+        return tr.rolling(length).mean()
+
+    pta.rsi = _rsi
+    pta.sma = _sma
+    pta.ema = _ema
+    pta.macd = _macd
+    pta.bbands = _bbands
+    pta.atr = _atr
+
+    sys.modules["pandas_ta"] = pta

--- a/optopsy/__init__.py
+++ b/optopsy/__init__.py
@@ -60,6 +60,7 @@ from .strategies import (
 from .datafeeds import csv_data
 from .types import StrategyParams, CalendarStrategyParams
 from .signals import (
+    apply_signal,
     rsi_below,
     rsi_above,
     day_of_week,
@@ -122,6 +123,7 @@ __all__ = [
     "StrategyParams",
     "CalendarStrategyParams",
     # Signal functions
+    "apply_signal",
     "rsi_below",
     "rsi_above",
     "day_of_week",

--- a/optopsy/checks.py
+++ b/optopsy/checks.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Tuple
 import pandas as pd
 
 expected_types: Dict[str, Tuple[str, ...]] = {
@@ -164,14 +164,8 @@ def _check_fill_ratio(key: str, value: Any) -> None:
         raise ValueError(f"Invalid setting for {key}, must be a number between 0 and 1")
 
 
-def _check_callable_or_none(key: str, value: Any) -> None:
-    """Validate that value is a callable or None."""
-    if value is not None and not callable(value):
-        raise ValueError(f"Invalid setting for {key}, must be a callable or None")
-
-
-def _check_stock_data(key: str, value: Any) -> None:
-    """Validate that value is a DataFrame with required columns, or None."""
+def _check_dates_dataframe(key: str, value: Any) -> None:
+    """Validate that value is a DataFrame with (underlying_symbol, quote_date), or None."""
     if value is None:
         return
     if not isinstance(value, pd.DataFrame):
@@ -180,12 +174,9 @@ def _check_stock_data(key: str, value: Any) -> None:
     missing = required - set(value.columns)
     if missing:
         raise ValueError(
-            f"stock_data missing required columns: {missing}. "
-            f"Expected at least: underlying_symbol, quote_date, "
-            f"and close (or underlying_price)."
+            f"{key} missing required columns: {missing}. "
+            f"Expected at least: underlying_symbol, quote_date."
         )
-    if "close" not in value.columns and "underlying_price" not in value.columns:
-        raise ValueError("stock_data must have a 'close' or 'underlying_price' column.")
 
 
 def _check_data_types(data: pd.DataFrame) -> None:
@@ -288,11 +279,9 @@ param_checks: Dict[str, Callable[[str, Any], None]] = {
     "front_dte_max": _check_positive_integer,
     "back_dte_min": _check_positive_integer,
     "back_dte_max": _check_positive_integer,
-    # Signal filtering
-    "entry_signal": _check_callable_or_none,
-    "exit_signal": _check_callable_or_none,
-    # External stock data for signals
-    "stock_data": _check_stock_data,
+    # Pre-computed signal dates
+    "entry_dates": _check_dates_dataframe,
+    "exit_dates": _check_dates_dataframe,
     # Slippage parameters
     "slippage": _check_slippage,
     "fill_ratio": _check_fill_ratio,

--- a/optopsy/strategies.py
+++ b/optopsy/strategies.py
@@ -43,11 +43,9 @@ default_kwargs: Dict[str, Any] = {
     "delta_max": None,
     # Greeks grouping (optional)
     "delta_interval": None,
-    # Signal filtering (optional)
-    "entry_signal": None,
-    "exit_signal": None,
-    # External stock data for signal computation (optional)
-    "stock_data": None,
+    # Pre-computed signal dates (optional) — use apply_signal() to generate
+    "entry_dates": None,
+    "exit_dates": None,
     # Slippage settings
     "slippage": "mid",  # "mid", "spread", or "liquidity"
     "fill_ratio": 0.5,  # Base fill ratio for liquidity mode (0.0-1.0)

--- a/optopsy/types.py
+++ b/optopsy/types.py
@@ -1,6 +1,6 @@
 """Type definitions for Optopsy strategy parameters."""
 
-from typing import Callable, Literal, Optional, TypedDict
+from typing import Literal, Optional, TypedDict
 
 import pandas as pd
 
@@ -29,16 +29,11 @@ class StrategyParams(TypedDict, total=False):
     # Greeks grouping (optional)
     delta_interval: Optional[float]
 
-    # Signal filtering (optional)
-    entry_signal: Optional[Callable[[pd.DataFrame], "pd.Series[bool]"]]
-    exit_signal: Optional[Callable[[pd.DataFrame], "pd.Series[bool]"]]
-
-    # External stock data for signal computation (optional).
-    # When provided, signals receive this OHLCV DataFrame instead of
-    # extracting prices from the option chain. Expected columns:
-    # underlying_symbol, quote_date, and at least close (or underlying_price).
-    # Optional OHLCV columns: open, high, low, volume.
-    stock_data: Optional[pd.DataFrame]
+    # Pre-computed signal dates (optional).
+    # DataFrames with (underlying_symbol, quote_date) pairs indicating
+    # valid dates for entry/exit.  Use signals.apply_signal() to generate.
+    entry_dates: Optional[pd.DataFrame]
+    exit_dates: Optional[pd.DataFrame]
 
     # Slippage settings
     slippage: Literal["mid", "spread", "liquidity"]


### PR DESCRIPTION
Signal computation is now the user's responsibility via the new
`apply_signal(data, signal_func)` helper, which returns a DataFrame of
valid (underlying_symbol, quote_date) pairs. Strategies accept
pre-computed `entry_dates` and `exit_dates` DataFrames instead of
`entry_signal`, `exit_signal`, and `stock_data` callables/data.

This removes the confusing coupling where the engine internally resolved
what data to feed signals and ran them. Users now control signal data
preparation end-to-end, making it clearer and more flexible (any data
source, custom models, manual date lists).

Key changes:
- Add `apply_signal()` in signals.py (exported from __init__)
- Remove `_extract_signal_dates`, `_prepare_stock_data`,
  `_resolve_signal_data`, `_get_signal_valid_dates` from core.py
- Replace `entry_signal`/`exit_signal`/`stock_data` params with
  `entry_dates`/`exit_dates` in strategies, types, and checks
- Update UI tools to call apply_signal() before passing to strategies
- Rewrite all integration tests for the new API

https://claude.ai/code/session_01VQ58yz9cQnt1CCuEqAb3dJ