### PR TITLE
Fix agent architecture bugs: shared state mutation, tool timeouts, redundant fetches

### DIFF
--- a/optopsy/ui/providers/eodhd.py
+++ b/optopsy/ui/providers/eodhd.py
@@ -535,6 +535,10 @@ class EODHDProvider(DataProvider):
     @staticmethod
     def _resolve_underlying_prices(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
         """Merge underlying close prices from yfinance into the DataFrame."""
+        # Drop any pre-existing underlying_price column to avoid duplicate
+        # suffixed columns (underlying_price_x / _y) from the merge.
+        if "underlying_price" in df.columns:
+            df = df.drop(columns=["underlying_price"])
         _log.info(
             "Resolving underlying prices via yfinance for %s (%s rows)",
             symbol,


### PR DESCRIPTION
- Deep-copy incoming messages in chat() so _compact_history does not
  mutate the caller's message dicts (conversation history stays
  full-fidelity for the session while the internal tool loop gets
  independently compacted for token savings)
- Add 120s timeout to tool execution via asyncio.wait_for to prevent
  hung API calls or large computations from blocking indefinitely
- Cache yfinance OHLCV data on the agent session (stock_cache dict)
  so repeated signal computations (build_signal, run_strategy with
  inline signals) reuse downloaded data instead of re-fetching
- Guard _resolve_underlying_prices against duplicate underlying_price
  columns by dropping any pre-existing column before the merge
- Build provider tool lookup dict once at startup for O(1) dispatch
  instead of linear scan on every tool call

https://claude.ai/code/session_01JCib7LipkB2mnrYG5iMFrw