### PR TITLE
Add Claude Code session start hook to install pre-commit in AI sandbox

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+VENV_DIR="$CLAUDE_PROJECT_DIR/venv"
+PYTHON="python3.12"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+  "$PYTHON" -m venv "$VENV_DIR"
+fi
+
+# Activate the virtual environment
+source "$VENV_DIR/bin/activate"
+
+# Install package in editable mode + dev tools
+# Prefer uv for speed, fall back to pip
+if command -v uv &>/dev/null; then
+  uv pip install -e .
+  uv pip install ruff mypy pytest pytest-cov pre-commit types-requests
+else
+  pip install -e .
+  pip install ruff mypy pytest pytest-cov pre-commit types-requests
+fi
+
+# Install pre-commit hooks into the git repo
+pre-commit install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,11 @@ MANIFEST
 *.swo
 
 /venv/
-.claude/
+# Claude Code - ignore local user config but track shared settings and hooks
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
 
 # Environment variables
 .env


### PR DESCRIPTION
Sets up a SessionStart hook that automatically creates a Python 3.12
venv, installs the package with dev tools (ruff, mypy, pytest,
pre-commit, types-requests), and runs `pre-commit install` when a
remote Claude Code session starts. Updates .gitignore to track
.claude/settings.json and hooks while keeping other .claude/ files
ignored.

https://claude.ai/code/session_01CMBHjXMbDPtXGpBHPHKqgU