### PR TITLE
Add risk metrics module with Sharpe, Sortino, VaR, CVaR, and more

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -23,10 +23,10 @@ source "$VENV_DIR/bin/activate"
 # Prefer uv for speed, fall back to pip
 if command -v uv &>/dev/null; then
   uv pip install -e .
-  uv pip install ruff mypy pytest pytest-cov pre-commit types-requests
+  uv pip install ruff mypy pytest pytest-cov pre-commit pandas-stubs types-requests
 else
   pip install -e .
-  pip install ruff mypy pytest pytest-cov pre-commit types-requests
+  pip install ruff mypy pytest pytest-cov pre-commit pandas-stubs types-requests
 fi
 
 # Install pre-commit hooks into the git repo

--- a/optopsy/metrics.py
+++ b/optopsy/metrics.py
@@ -271,8 +271,5 @@ def compute_risk_metrics(
 
 def _to_array(data: _ArrayLike) -> np.ndarray:
     """Convert input to a flat numpy array, dropping NaNs."""
-    if isinstance(data, pd.Series):
-        arr = data.to_numpy()
-    else:
-        arr = np.asarray(data)
+    arr = np.asarray(data)
     return arr[~np.isnan(arr)]


### PR DESCRIPTION
Implements roadmap item #1: Risk metrics from simulations.

New optopsy/metrics.py module provides standard risk-adjusted performance
metrics: Sharpe ratio, Sortino ratio, max drawdown, Value at Risk (95%),
Conditional VaR (95%), win rate, profit factor, and Calmar ratio.

Integration points:
- simulator._compute_summary() now includes all 5 new risk metrics
  (Sharpe, Sortino, VaR, CVaR, Calmar) alongside existing stats
- core._group_by_intervals() adds win_rate and profit_factor to
  aggregated strategy output per DTE/OTM group
- UI simulate handler displays new metrics in summary table and LLM context
- _make_result_summary and scan_strategies include profit_factor
- StrategyResultSummary model extended with profit_factor field
- All metrics exported from optopsy public API

https://claude.ai/code/session_011XEoa247u6dnEwFksVvp4h