### PR TITLE
Add IV rank signals and volatility surface tools (roadmap item #2)

### DIFF
--- a/optopsy/ui/providers/eodhd.py
+++ b/optopsy/ui/providers/eodhd.py
@@ -56,7 +56,7 @@ _OPTIONS_NUMERIC_COLS = [
     "gamma",
     "theta",
     "vega",
-    "impliedVolatility",
+    "implied_volatility",
     "open_interest",
     "midpoint",
 ]


### PR DESCRIPTION
Phase 1 — Preserve implied volatility through the data pipeline:
- EODHD provider: fetch impliedVolatility field, map to implied_volatility,
  include in numeric coercion and column selection
- datafeeds.csv_data(): add implied_volatility optional column parameter
- checks.py: add implied_volatility to optional_greek_types validation

Phase 2 — IV rank/percentile entry/exit signals:
- signals.py: add _compute_atm_iv(), _compute_iv_rank_series(),
  iv_rank_above(), iv_rank_below() signal functions
- _schemas.py: register in SIGNAL_REGISTRY with _IV_SIGNALS set
- _models.py: update SignalMixin descriptions with IV rank params
- _executor.py/_helpers.py: route IV signals to options dataset
  instead of stock OHLCV data, handle in run_strategy, simulate,
  and build_signal handlers

Phase 3 — IV surface visualization tools:
- plot_vol_surface: heatmap of IV by strike × expiration for a given date
- iv_term_structure: ATM IV across expirations (DTE on x-axis)
- Both registered as tools with Pydantic models and schema descriptions

Tests: 20 new tests covering ATM IV computation, IV rank series,
signal functions, apply_signal integration, and multi-symbol isolation.

https://claude.ai/code/session_016EcNQuiwMM1h4zDLXgpyrs