### PR TITLE
Add risk metrics module with Sharpe, Sortino, VaR, CVaR, and more

### DIFF
--- a/optopsy/core.py
+++ b/optopsy/core.py
@@ -209,28 +209,20 @@ def _group_by_intervals(
     grouped = data.groupby(cols, observed=True)["pct_change"]
     grouped_dataset = grouped.describe()
 
-    # Compute win_rate and profit_factor per group
-    def _extra_metrics(series: pd.Series) -> pd.Series:
-        valid = series.dropna()
-        if len(valid) == 0:
-            return pd.Series({"win_rate": np.nan, "profit_factor": np.nan})
-        wr = float((valid > 0).sum()) / len(valid)
-        wins = valid[valid > 0].sum()
-        losses = valid[valid < 0].sum()
-        if losses == 0:
-            pf = np.nan
-        else:
-            pf = abs(float(wins) / float(losses))
-        return pd.Series({"win_rate": wr, "profit_factor": pf})
+    # Compute win_rate and profit_factor per group using vectorized aggregation
+    win_counts = grouped.agg(lambda s: (s.dropna() > 0).sum())
+    valid_counts = grouped.agg(lambda s: s.dropna().shape[0])
+    gross_wins = grouped.agg(lambda s: s[s > 0].sum())
+    gross_losses = grouped.agg(lambda s: s[s < 0].sum())
 
-    extra = grouped.apply(_extra_metrics)
-    # Single-level groupby: apply returns a DataFrame directly.
-    # Multi-level groupby: apply returns a Series with an extra index level;
-    # unstack() pivots that level into columns to match grouped_dataset shape.
-    if isinstance(extra, pd.DataFrame):
-        grouped_dataset = pd.concat([grouped_dataset, extra], axis=1)
-    else:
-        grouped_dataset = pd.concat([grouped_dataset, extra.unstack()], axis=1)
+    grouped_dataset["win_rate"] = np.where(
+        valid_counts > 0, win_counts / valid_counts, np.nan
+    )
+    grouped_dataset["profit_factor"] = np.where(
+        gross_losses != 0,
+        np.abs(gross_wins / gross_losses),
+        np.where(gross_wins > 0, np.inf, 0.0),
+    )
 
     # if any non-count columns return NaN remove the row
     if drop_na:

--- a/optopsy/simulator.py
+++ b/optopsy/simulator.py
@@ -420,12 +420,14 @@ def _compute_summary(trade_log: pd.DataFrame, capital: float) -> dict[str, Any]:
     equity = trade_log["equity"]
     max_dd = _max_drawdown(equity)
 
-    # Risk-adjusted metrics from per-trade returns.
-    # NOTE: These are per-trade returns, not daily returns. The default 252-day
-    # annualisation factor in sharpe/sortino/calmar may overstate ratios when
-    # trades occur less frequently than daily. For more accurate annualised
-    # metrics, pass a trading_days value matching the actual trade cadence.
-    returns = trade_log["pct_change"]
+    # Derive daily returns from the equity curve for annualised metrics
+    # (Sharpe, Sortino, Calmar).  Per-trade returns are NOT daily, so
+    # annualising them with trading_days=252 would materially overstate
+    # ratios when trades occur less frequently than daily.
+    daily_returns = equity.pct_change().dropna()
+
+    # Per-trade returns are still correct for VaR/CVaR (no annualisation).
+    per_trade_returns = trade_log["pct_change"]
 
     return {
         "total_trades": len(trade_log),
@@ -446,11 +448,11 @@ def _compute_summary(trade_log: pd.DataFrame, capital: float) -> dict[str, Any]:
         ),
         "max_drawdown": max_dd,
         "avg_days_in_trade": float(trade_log["days_held"].mean()),
-        "sharpe_ratio": sharpe_ratio(returns),
-        "sortino_ratio": sortino_ratio(returns),
-        "var_95": value_at_risk(returns, 0.95),
-        "cvar_95": conditional_value_at_risk(returns, 0.95),
-        "calmar_ratio": calmar_ratio(returns),
+        "sharpe_ratio": sharpe_ratio(daily_returns),
+        "sortino_ratio": sortino_ratio(daily_returns),
+        "var_95": value_at_risk(per_trade_returns, 0.95),
+        "cvar_95": conditional_value_at_risk(per_trade_returns, 0.95),
+        "calmar_ratio": calmar_ratio(daily_returns),
     }
 
 

--- a/optopsy/ui/tools/_helpers.py
+++ b/optopsy/ui/tools/_helpers.py
@@ -441,7 +441,7 @@ def _make_result_summary(
         wins = pct[pct > 0].sum()
         losses = pct[pct < 0].sum()
         if losses == 0:
-            pf = np.nan
+            pf = float("inf") if float(wins) > 0 else 0.0
         else:
             pf = abs(float(wins) / float(losses))
         base.update(


### PR DESCRIPTION
Implements roadmap item #1: Risk metrics from simulations.

New optopsy/metrics.py module provides standard risk-adjusted performance
metrics: Sharpe ratio, Sortino ratio, max drawdown, Value at Risk (95%),
Conditional VaR (95%), win rate, profit factor, and Calmar ratio.

Integration points:
- simulator._compute_summary() now includes all 5 new risk metrics
  (Sharpe, Sortino, VaR, CVaR, Calmar) alongside existing stats
- core._group_by_intervals() adds win_rate and profit_factor to
  aggregated strategy output per DTE/OTM group
- UI simulate handler displays new metrics in summary table and LLM context
- _make_result_summary and scan_strategies include profit_factor
- StrategyResultSummary model extended with profit_factor field
- All metrics exported from optopsy public API

https://claude.ai/code/session_011XEoa247u6dnEwFksVvp4h