### PR TITLE
Add IV rank signals and volatility surface tools (roadmap item #2)

### DIFF
--- a/optopsy/signals.py
+++ b/optopsy/signals.py
@@ -634,13 +634,19 @@ def iv_rank_above(threshold: float = 0.5, window: int = 252) -> SignalFunc:
             return pd.Series(False, index=data.index)
         rank = _compute_iv_rank_series(atm_iv, window)
         # Map rank back to original data rows via (symbol, quote_date)
-        rank_map = atm_iv[["underlying_symbol", "quote_date"]].copy()
-        rank_map["_iv_rank"] = rank.values
-        merged = data[["underlying_symbol", "quote_date"]].merge(
-            rank_map, on=["underlying_symbol", "quote_date"], how="left"
+        rank_lookup = pd.Series(
+            rank.values,
+            index=pd.MultiIndex.from_arrays(
+                [atm_iv["underlying_symbol"], atm_iv["quote_date"]]
+            ),
         )
-        return (merged["_iv_rank"] > threshold).fillna(False)
+        keys = pd.MultiIndex.from_arrays(
+            [data["underlying_symbol"], data["quote_date"]]
+        )
+        iv_rank_for_rows = pd.Series(rank_lookup.reindex(keys).values, index=data.index)
+        return (iv_rank_for_rows > threshold).fillna(False)
 
+    _signal.requires_per_strike = True  # type: ignore[attr-defined]
     return _signal
 
 
@@ -669,13 +675,19 @@ def iv_rank_below(threshold: float = 0.5, window: int = 252) -> SignalFunc:
         if atm_iv.empty:
             return pd.Series(False, index=data.index)
         rank = _compute_iv_rank_series(atm_iv, window)
-        rank_map = atm_iv[["underlying_symbol", "quote_date"]].copy()
-        rank_map["_iv_rank"] = rank.values
-        merged = data[["underlying_symbol", "quote_date"]].merge(
-            rank_map, on=["underlying_symbol", "quote_date"], how="left"
+        rank_lookup = pd.Series(
+            rank.values,
+            index=pd.MultiIndex.from_arrays(
+                [atm_iv["underlying_symbol"], atm_iv["quote_date"]]
+            ),
         )
-        return (merged["_iv_rank"] < threshold).fillna(False)
+        keys = pd.MultiIndex.from_arrays(
+            [data["underlying_symbol"], data["quote_date"]]
+        )
+        iv_rank_for_rows = pd.Series(rank_lookup.reindex(keys).values, index=data.index)
+        return (iv_rank_for_rows < threshold).fillna(False)
 
+    _signal.requires_per_strike = True  # type: ignore[attr-defined]
     return _signal
 
 
@@ -924,15 +936,19 @@ def apply_signal(data: pd.DataFrame, signal_func: SignalFunc) -> pd.DataFrame:
         df["underlying_price"] = df["close"]
     df["quote_date"] = normalize_dates(df["quote_date"])
     # IV-rank signals need multiple strikes per (symbol, date) to compute
-    # ATM IV.  Only deduplicate when the data lacks per-strike option rows.
-    if "implied_volatility" not in df.columns:
+    # ATM IV.  Only skip dedup when the signal explicitly requires per-strike
+    # rows (via the requires_per_strike attribute).  Other signals (RSI, SMA,
+    # MACD, ATR, etc.) must always see deduplicated rows even when the
+    # dataset happens to contain an implied_volatility column.
+    requires_per_strike = getattr(signal_func, "requires_per_strike", False)
+    if requires_per_strike:
+        df = df.sort_values(["underlying_symbol", "quote_date"]).reset_index(drop=True)
+    else:
         df = (
             df.drop_duplicates(["underlying_symbol", "quote_date"])
             .sort_values(["underlying_symbol", "quote_date"])
             .reset_index(drop=True)
         )
-    else:
-        df = df.sort_values(["underlying_symbol", "quote_date"]).reset_index(drop=True)
     mask = signal_func(df)
     return (
         df.loc[mask, ["underlying_symbol", "quote_date"]]

--- a/optopsy/ui/tools/_executor.py
+++ b/optopsy/ui/tools/_executor.py
@@ -412,11 +412,16 @@ def _handle_build_signal(arguments, dataset, signals, datasets, results, _result
     # data. Combining them in a single build_signal call is not supported
     # because each type requires a different dataset shape.
     if has_iv_signal and needs_stock:
-        iv_names = [s["name"] for s in signal_specs if s.get("name") in _IV_SIGNALS]
-        stock_names = [
-            s["name"]
+        iv_names = [
+            s.get("name")
             for s in signal_specs
-            if s.get("name") not in _DATE_ONLY_SIGNALS
+            if s.get("name") and s.get("name") in _IV_SIGNALS
+        ]
+        stock_names = [
+            s.get("name")
+            for s in signal_specs
+            if s.get("name")
+            and s.get("name") not in _DATE_ONLY_SIGNALS
             and s.get("name") not in _IV_SIGNALS
         ]
         return _result(
@@ -1701,9 +1706,9 @@ def _handle_plot_vol_surface(arguments, dataset, signals, datasets, results, _re
                 f"Try quote_date='{closest}'."
             )
     else:
-        latest = ds["quote_date"].max()
-        df = ds[ds["quote_date"] == latest].copy()
-        quote_date_str = str(latest.date())
+        latest_day = ds["quote_date"].dt.normalize().max()
+        df = ds[ds["quote_date"].dt.normalize() == latest_day].copy()
+        quote_date_str = str(latest_day.date())
 
     option_type = arguments.get("option_type", "call")
     ot = option_type.lower()[:1]
@@ -1784,9 +1789,10 @@ def _handle_iv_term_structure(arguments, dataset, signals, datasets, results, _r
                 f"Try quote_date='{closest}'."
             )
     else:
-        latest = ds["quote_date"].max()
-        df = ds[ds["quote_date"] == latest].copy()
-        quote_date_str = str(latest.date())
+        normalized_dates = ds["quote_date"].dt.normalize()
+        latest_day = normalized_dates.max()
+        df = ds[normalized_dates == latest_day].copy()
+        quote_date_str = str(latest_day.date())
 
     df = df.dropna(subset=["implied_volatility", "underlying_price"])
 

--- a/optopsy/ui/tools/_models.py
+++ b/optopsy/ui/tools/_models.py
@@ -714,8 +714,8 @@ class PlotVolSurfaceArgs(BaseModel):
             "Omit for the latest date in the dataset."
         ),
     )
-    option_type: Literal["call", "put"] | None = Field(
-        None,
+    option_type: Literal["call", "put"] = Field(
+        "call",
         description="Option type to plot. Default: 'call'.",
     )
     figsize_width: int | None = Field(


### PR DESCRIPTION
Phase 1 — Preserve implied volatility through the data pipeline:
- EODHD provider: fetch impliedVolatility field, map to implied_volatility,
  include in numeric coercion and column selection
- datafeeds.csv_data(): add implied_volatility optional column parameter
- checks.py: add implied_volatility to optional_greek_types validation

Phase 2 — IV rank/percentile entry/exit signals:
- signals.py: add _compute_atm_iv(), _compute_iv_rank_series(),
  iv_rank_above(), iv_rank_below() signal functions
- _schemas.py: register in SIGNAL_REGISTRY with _IV_SIGNALS set
- _models.py: update SignalMixin descriptions with IV rank params
- _executor.py/_helpers.py: route IV signals to options dataset
  instead of stock OHLCV data, handle in run_strategy, simulate,
  and build_signal handlers

Phase 3 — IV surface visualization tools:
- plot_vol_surface: heatmap of IV by strike × expiration for a given date
- iv_term_structure: ATM IV across expirations (DTE on x-axis)
- Both registered as tools with Pydantic models and schema descriptions

Tests: 20 new tests covering ATM IV computation, IV rank series,
signal functions, apply_signal integration, and multi-symbol isolation.

https://claude.ai/code/session_016EcNQuiwMM1h4zDLXgpyrs