### PR TITLE
Add risk metrics module with Sharpe, Sortino, VaR, CVaR, and more

### DIFF
--- a/optopsy/core.py
+++ b/optopsy/core.py
@@ -209,11 +209,27 @@ def _group_by_intervals(
     grouped = data.groupby(cols, observed=True)["pct_change"]
     grouped_dataset = grouped.describe()
 
-    # Compute win_rate and profit_factor per group using vectorized aggregation
-    win_counts = grouped.agg(lambda s: (s.dropna() > 0).sum())
-    valid_counts = grouped.agg(lambda s: s.dropna().shape[0])
-    gross_wins = grouped.agg(lambda s: s[s > 0].sum())
-    gross_losses = grouped.agg(lambda s: s[s < 0].sum())
+    # Compute win_rate and profit_factor per group using fully vectorized
+    # operations.  Pre-compute boolean/masked columns once, then let
+    # groupby.sum() run at C level — avoids per-group Python lambdas and
+    # repeated dropna() calls.
+    pct = data["pct_change"]
+    _metrics = pd.DataFrame(
+        {
+            "_valid": pct.notna().astype(int),
+            "_win": (pct > 0).astype(int),
+            "_win_amt": pct.where(pct > 0, 0.0).fillna(0.0),
+            "_loss_amt": pct.where(pct < 0, 0.0).fillna(0.0),
+        },
+        index=data.index,
+    )
+    for c in cols:
+        _metrics[c] = data[c]
+    _g = _metrics.groupby(cols, observed=True)
+    valid_counts = _g["_valid"].sum()
+    win_counts = _g["_win"].sum()
+    gross_wins = _g["_win_amt"].sum()
+    gross_losses = _g["_loss_amt"].sum()
 
     grouped_dataset["win_rate"] = np.where(
         valid_counts > 0, win_counts / valid_counts, np.nan

--- a/optopsy/simulator.py
+++ b/optopsy/simulator.py
@@ -420,11 +420,27 @@ def _compute_summary(trade_log: pd.DataFrame, capital: float) -> dict[str, Any]:
     equity = trade_log["equity"]
     max_dd = _max_drawdown(equity)
 
-    # Derive daily returns from the equity curve for annualised metrics
-    # (Sharpe, Sortino, Calmar).  Per-trade returns are NOT daily, so
-    # annualising them with trading_days=252 would materially overstate
-    # ratios when trades occur less frequently than daily.
-    daily_returns = equity.pct_change().dropna()
+    # Derive true daily returns from the equity curve for annualised
+    # metrics (Sharpe, Sortino, Calmar).  The equity curve is indexed by
+    # trade exit dates which are NOT evenly spaced.  Resampling to daily
+    # frequency with forward-fill ensures pct_change() produces genuine
+    # daily returns suitable for the 252-day annualisation factor.
+    _has_dates = "exit_date" in trade_log.columns and "entry_date" in trade_log.columns
+    if _has_dates:
+        equity_daily = trade_log.set_index("exit_date")["equity"].copy()
+        equity_daily.index = pd.to_datetime(equity_daily.index)
+        # Prepend initial capital at the first entry date so the full
+        # period is represented (including flat days before first exit).
+        first_entry = pd.to_datetime(trade_log["entry_date"].iloc[0])
+        if first_entry not in equity_daily.index:
+            equity_daily.loc[first_entry] = capital
+            equity_daily = equity_daily.sort_index()
+        equity_daily = equity_daily.resample("D").ffill()
+        daily_returns = equity_daily.pct_change().dropna()
+    else:
+        # Fallback for minimal trade logs (e.g. unit tests) without date
+        # columns — use inter-trade equity changes.
+        daily_returns = equity.pct_change().dropna()
 
     # Per-trade returns are still correct for VaR/CVaR (no annualisation).
     per_trade_returns = trade_log["pct_change"]

--- a/optopsy/ui/tools/_helpers.py
+++ b/optopsy/ui/tools/_helpers.py
@@ -4,7 +4,6 @@ import re
 from datetime import date, timedelta
 from typing import Any
 
-import numpy as np
 import pandas as pd
 
 import optopsy.signals as _signals
@@ -438,12 +437,13 @@ def _make_result_summary(
     }
     if "pct_change" in result_df.columns:
         pct = result_df["pct_change"].dropna()
-        wins = pct[pct > 0].sum()
-        losses = pct[pct < 0].sum()
+        wins = float(pct[pct > 0].sum())
+        losses = float(pct[pct < 0].sum())
         if losses == 0:
-            pf = float("inf") if float(wins) > 0 else 0.0
+            pf = float("inf") if wins > 0 else 0.0
         else:
-            pf = abs(float(wins) / float(losses))
+            # Match metrics.profit_factor pattern: abs(wins) / abs(losses)
+            pf = abs(wins) / abs(losses)
         base.update(
             {
                 "count": len(pct),
@@ -460,23 +460,23 @@ def _make_result_summary(
         else:
             total = len(result_df)
             wt_mean = float(result_df["mean"].mean())
-        # Extract weighted profit_factor from aggregated output if available.
-        # Filter out inf values before averaging — groups with no losses
-        # have inf profit_factor which would dominate a weighted average.
+        # Compute aggregated profit_factor by combining gross wins and
+        # losses across all groups, then dividing.  This avoids the
+        # pitfall of weighted-averaging per-group profit factors where
+        # inf values (groups with no losses) would dominate or need
+        # filtering — which would make the aggregate not equal the true
+        # all-trades combined ratio.
         agg_pf = None
-        if "profit_factor" in result_df.columns and "count" in result_df.columns:
-            valid = result_df[
-                result_df["profit_factor"].notna()
-                & np.isfinite(result_df["profit_factor"])
-            ]
-            if not valid.empty:
-                agg_pf = round(
-                    float(
-                        (valid["profit_factor"] * valid["count"]).sum()
-                        / valid["count"].sum()
-                    ),
-                    4,
-                )
+        if "mean" in result_df.columns and "count" in result_df.columns:
+            group_pnl = result_df["mean"] * result_df["count"]
+            total_wins = float(group_pnl[group_pnl > 0].sum())
+            total_losses = float(group_pnl[group_pnl < 0].sum())
+            if total_losses != 0:
+                agg_pf = round(abs(total_wins) / abs(total_losses), 4)
+            elif total_wins > 0:
+                agg_pf = float("inf")
+            else:
+                agg_pf = 0.0
         base.update(
             {
                 "count": total,


### PR DESCRIPTION
Implements roadmap item #1: Risk metrics from simulations.

New optopsy/metrics.py module provides standard risk-adjusted performance
metrics: Sharpe ratio, Sortino ratio, max drawdown, Value at Risk (95%),
Conditional VaR (95%), win rate, profit factor, and Calmar ratio.

Integration points:
- simulator._compute_summary() now includes all 5 new risk metrics
  (Sharpe, Sortino, VaR, CVaR, Calmar) alongside existing stats
- core._group_by_intervals() adds win_rate and profit_factor to
  aggregated strategy output per DTE/OTM group
- UI simulate handler displays new metrics in summary table and LLM context
- _make_result_summary and scan_strategies include profit_factor
- StrategyResultSummary model extended with profit_factor field
- All metrics exported from optopsy public API

https://claude.ai/code/session_011XEoa247u6dnEwFksVvp4h