### PR TITLE
Add pre-push hook to enforce branch naming convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,11 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      - id: branch-name
+        name: branch name check
+        entry: bash scripts/check-branch-name.sh
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,28 @@ Pluggable provider system for fetching market data.
 3. Register in `providers/__init__.py`
 4. Provider is auto-detected if its `env_key` is set
 
+## Git Branching Convention
+
+Branch names are enforced by a `pre-push` hook (via pre-commit). All branches must use one of these prefixes:
+
+| Prefix | Use case |
+|---|---|
+| `feature/` | New features |
+| `fix/` | Bug fixes |
+| `bugfix/` | Bug fixes (alias) |
+| `hotfix/` | Urgent production fixes |
+| `release/` | Release preparation |
+| `claude/` | Claude-generated branches |
+| `master` | Main branch (no prefix) |
+
+Example: `feature/add-iron-condor-strategy`, `fix/dte-filter-bug`, `claude/refactor-core`
+
+After cloning, install the pre-push hook:
+
+```bash
+uv run pre-commit install --hook-type pre-push
+```
+
 ## Releasing
 
 Publishing to PyPI is automated via GitHub Actions (`.github/workflows/python-publish.yml`) using trusted publishing. To release:

--- a/scripts/check-branch-name.sh
+++ b/scripts/check-branch-name.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if ! echo "$branch" | grep -qE "^(feature|fix|bugfix|hotfix|release|claude)/|^master$"; then
+    echo "ERROR: Branch \"$branch\" does not follow naming convention."
+    echo "Allowed prefixes: feature/, fix/, bugfix/, hotfix/, release/, claude/"
+    echo "Example: feature/add-new-strategy"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a `pre-push` hook via pre-commit that enforces branch naming conventions
- Allowed prefixes: `feature/`, `fix/`, `bugfix/`, `hotfix/`, `release/`, `claude/`, and `master`
- Extracts the check into `scripts/check-branch-name.sh` for maintainability

## Test plan
- [x] Verified hook passes on a conforming branch (`feature/enforce-branch-naming`)
- [ ] Test that pushing from a non-conforming branch name is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)