### PR TITLE
Add comprehensive docstrings and inline comments

### DIFF
--- a/optopsy/checks.py
+++ b/optopsy/checks.py
@@ -1,7 +1,26 @@
+"""Parameter and data validation for option strategy inputs.
+
+This module validates two things before a strategy runs:
+
+1. **Parameter checks** — Each user-supplied parameter (DTE intervals, OTM %,
+   slippage mode, etc.) is validated by a type-specific checker function.  The
+   ``param_checks`` dict at module level maps parameter names to their checkers.
+
+2. **DataFrame schema checks** — The input DataFrame must contain the required
+   columns (``expected_types``) with compatible dtypes.  Optional columns for
+   Greeks (``optional_greek_types``) and liquidity (``optional_liquidity_types``)
+   are validated only when the corresponding features are enabled.
+
+Entry points:
+- ``_run_checks()`` — standard strategies (validates params, dtypes, delta)
+- ``_run_calendar_checks()`` — calendar/diagonal spreads (adds DTE range ordering)
+"""
+
 from typing import Any, Callable, Dict, Tuple
 
 import pandas as pd
 
+# Required columns and their accepted dtypes for option chain DataFrames.
 expected_types: Dict[str, Tuple[str, ...]] = {
     "underlying_symbol": ("object", "str"),
     "underlying_price": ("int64", "float64"),
@@ -13,7 +32,7 @@ expected_types: Dict[str, Tuple[str, ...]] = {
     "ask": ("int64", "float64"),
 }
 
-# Optional Greek columns - only validated when Greeks filtering/grouping is enabled
+# Optional Greek columns — validated only when delta filtering/grouping is enabled.
 optional_greek_types: Dict[str, Tuple[str, ...]] = {
     "delta": ("int64", "float64"),
     "gamma": ("int64", "float64"),
@@ -22,7 +41,7 @@ optional_greek_types: Dict[str, Tuple[str, ...]] = {
     "implied_volatility": ("int64", "float64"),
 }
 
-# Optional liquidity columns - only validated when liquidity slippage is enabled
+# Optional liquidity columns — validated only when slippage="liquidity" is enabled.
 optional_liquidity_types: Dict[str, Tuple[str, ...]] = {
     "volume": ("int64", "float64"),
     "open_interest": ("int64", "float64"),
@@ -267,6 +286,9 @@ def _check_volume_column(data: pd.DataFrame) -> None:
         )
 
 
+# Maps parameter name → validation function.  Each checker raises ValueError
+# if the value is invalid.  Used by ``_run_common_checks()`` to validate all
+# user-supplied strategy parameters before execution.
 param_checks: Dict[str, Callable[[str, Any], None]] = {
     "dte_interval": _check_positive_integer,
     "max_entry_dte": _check_positive_integer,

--- a/optopsy/core.py
+++ b/optopsy/core.py
@@ -1,3 +1,21 @@
+"""Strategy execution engine for options backtesting.
+
+This module implements the core pipeline that transforms raw option chain data
+into strategy performance results. The pipeline flows through several stages:
+
+1. **Validation** — ``_run_checks()`` verifies parameter types and DataFrame schemas.
+2. **Evaluation** — ``_evaluate_all_options()`` filters by DTE, OTM%, bid/ask thresholds,
+   and optionally delta; then merges entry and exit rows for each contract.
+3. **Strategy construction** — ``_strategy_engine()`` joins legs (single or multi-leg),
+   applies strike-ordering rules, and calculates P&L with optional slippage.
+4. **Output formatting** — ``_format_output()`` returns raw trades or grouped
+   descriptive statistics (with win_rate and profit_factor).
+
+Calendar and diagonal spreads follow a parallel path via
+``_process_calendar_strategy()``, which handles different expirations per leg
+and a dedicated exit-price matching step.
+"""
+
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -445,15 +463,20 @@ def _apply_ratios(
         volume_col = f"volume_entry_leg{idx}"
 
         leg = leg_def[idx - 1]
-        side_value = leg[0].value
+        side_value = leg[0].value  # +1 (long/buy) or -1 (short/sell)
         quantity = _get_leg_quantity(leg)
+        # Combined multiplier: direction × quantity, e.g. short 2 calls → -2
         multiplier = side_value * quantity
 
         # Check if bid/ask columns exist for slippage calculation
         has_bid_ask = bid_entry_col in data.columns and ask_entry_col in data.columns
 
         if has_bid_ask and slippage != "mid":
-            # Calculate fill price based on slippage model
+            # Slippage recalculates fill prices from raw bid/ask rather than
+            # using the midpoint.  Long entries fill closer to the ask (worse
+            # price for buyer); short entries fill closer to the bid (worse
+            # price for seller).  The degree depends on the slippage model:
+            # "spread" uses the full spread; "liquidity" scales by volume.
             volume_entry = data.get(volume_col) if volume_col in data.columns else None
 
             # Entry: use side_value to determine buy/sell direction
@@ -605,15 +628,21 @@ def _strategy_engine(
     ) -> pd.DataFrame:
         return d if r is None else r(d, ld)
 
-    # Pre-rename columns for each leg to avoid suffix issues with 3+ legs.
-    # .rename() already returns a new DataFrame, so .copy() is unnecessary.
+    # Multi-leg construction:
+    # 1. Filter data for each leg's option type (calls/puts) and pre-rename
+    #    columns with _legN suffixes to avoid ambiguity during merges.
+    # 2. Sequentially inner-join all legs on shared columns (symbol,
+    #    expiration, DTE, etc.) to produce every valid leg combination.
+    # 3. Apply strategy-specific rules (e.g. ascending strikes, equal wings).
+    # 4. Calculate P&L across all legs with slippage adjustments.
     partials = [
         _rename_leg_columns(leg[1](data), idx, join_on or [])
         for idx, leg in enumerate(leg_def, start=1)
     ]
     suffixes = [f"_leg{idx}" for idx in range(1, len(leg_def) + 1)]
 
-    # Merge all legs sequentially
+    # Merge all legs sequentially on shared columns (inner join ensures
+    # only rows present in ALL legs are kept)
     result = partials[0]
     for partial in partials[1:]:
         result = pd.merge(result, partial, on=join_on, how="inner")

--- a/optopsy/datafeeds.py
+++ b/optopsy/datafeeds.py
@@ -1,3 +1,16 @@
+"""CSV data import and column normalization for option chain data.
+
+The primary entry point is ``csv_data()``, which reads a CSV file and maps
+its columns to the standardized names used throughout optopsy (e.g.
+``underlying_symbol``, ``quote_date``, ``strike``).  Column positions are
+specified by integer index, allowing the library to work with any CSV layout.
+
+The module also handles:
+- Date column inference (``_infer_date_cols``)
+- Optional date-range filtering (``_trim_dates``)
+- Optional Greek and liquidity columns (delta, gamma, volume, etc.)
+"""
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd

--- a/optopsy/rules.py
+++ b/optopsy/rules.py
@@ -1,3 +1,19 @@
+"""Strike and expiration validation rules for multi-leg option strategies.
+
+Each rule function receives a DataFrame of candidate leg combinations and a
+leg definition list, then filters out rows that violate the strategy's
+structural constraints.  Rules are passed to ``core._strategy_engine()`` via
+the ``rules`` parameter and are applied after legs are joined but before
+P&L calculation.
+
+Rule functions:
+- ``_rule_non_overlapping_strike`` — ascending strike ordering for spreads/strangles
+- ``_rule_butterfly_strikes`` — ascending strikes with equal-width wings
+- ``_rule_iron_condor_strikes`` — four strictly ascending strikes
+- ``_rule_iron_butterfly_strikes`` — four strikes where middle two are equal
+- ``_rule_expiration_ordering`` — front leg expires before back leg (calendar/diagonal)
+"""
+
 from typing import List, Tuple
 
 import pandas as pd

--- a/optopsy/strategies.py
+++ b/optopsy/strategies.py
@@ -1,3 +1,23 @@
+"""Public API for options strategy backtesting.
+
+Each strategy function (e.g. ``long_calls``, ``iron_condor``) accepts a DataFrame
+of option chain data and optional ``StrategyParams`` keyword arguments, then
+returns a DataFrame of either raw trades or aggregated descriptive statistics.
+
+**Pattern:** Every public function delegates to a private helper (``_singles``,
+``_spread``, ``_butterfly``, etc.) that assembles leg definitions and calls
+``core._process_strategy()`` (or ``_process_calendar_strategy()`` for calendar
+and diagonal spreads).
+
+**Leg definitions** are lists of tuples: ``(Side.long/short, filter_fn, quantity)``.
+The ``Side`` enum encodes direction as a multiplier (``long=1``, ``short=-1``).
+``filter_fn`` is ``_calls`` or ``_puts`` from ``core.py``.
+
+**Default parameters** are defined in ``default_kwargs`` (standard strategies) and
+``calendar_default_kwargs`` (calendar/diagonal spreads).  Users override any
+parameter via keyword arguments.
+"""
+
 from enum import Enum
 from typing import Any, Dict, List, Tuple
 

--- a/optopsy/ui/agent.py
+++ b/optopsy/ui/agent.py
@@ -1,3 +1,23 @@
+"""LLM agent with tool-calling loop for interactive options backtesting.
+
+The ``OptopsyAgent`` class manages the conversation loop:
+
+1. Send messages + tool schemas to the LLM via LiteLLM (streaming).
+2. If the LLM emits tool calls, execute them via ``execute_tool()`` and
+   append the results to the conversation.
+3. Repeat until the LLM produces a final text response (no tool calls).
+
+Key design decisions:
+
+- **Message compaction** — After each iteration, old tool results and
+  intermediate assistant messages are truncated to ``_COMPACT_THRESHOLD``
+  characters to keep token usage manageable across many iterations.
+- **Iteration cap** — ``_MAX_TOOL_ITERATIONS`` prevents runaway loops.
+- **State** — The agent holds mutable state: ``dataset`` (active DataFrame),
+  ``datasets`` (named registry), ``signals`` (named signal slots), and
+  ``results`` (session-scoped strategy run summaries).
+"""
+
 import asyncio
 import functools
 import json
@@ -327,6 +347,12 @@ def _compact_history(messages: list[dict[str, Any]]) -> None:
 
 
 class OptopsyAgent:
+    """Tool-calling LLM agent for options strategy backtesting.
+
+    Wraps LiteLLM to stream responses, execute tools, and manage session
+    state (datasets, signals, strategy results) across conversation turns.
+    """
+
     def __init__(self, model: str = "anthropic/claude-haiku-4-5-20251001"):
         self.model = model
         self.tools = get_tool_schemas()

--- a/optopsy/ui/app.py
+++ b/optopsy/ui/app.py
@@ -1,3 +1,16 @@
+"""Chainlit web application for the Optopsy Chat UI.
+
+This module is the Chainlit entry point.  It sets up:
+
+- **Database** — SQLite-backed persistence for chat threads, steps, and feedback
+  (``_init_db_sync()``).
+- **Authentication** — Header-based auto-auth for single-user local use.
+- **Session lifecycle** — ``on_chat_start`` creates a fresh ``OptopsyAgent``;
+  ``on_chat_resume`` rebuilds message history from persisted steps.
+- **Message handling** — ``on_message`` processes user input, handles CSV
+  drag-and-drop uploads, and streams LLM responses with tool-call step UI.
+"""
+
 import json
 import logging
 import os

--- a/optopsy/ui/cli.py
+++ b/optopsy/ui/cli.py
@@ -8,6 +8,7 @@ import os
 
 
 def _format_bytes(n: int | float) -> str:
+    """Format a byte count as a human-readable string (e.g. ``"1.2 MB"``)."""
     for unit in ("B", "KB", "MB", "GB"):
         if n < 1024:
             return f"{n:.1f} {unit}"
@@ -16,6 +17,7 @@ def _format_bytes(n: int | float) -> str:
 
 
 def _cmd_cache_size(args: argparse.Namespace) -> None:
+    """Print per-symbol cache sizes and a total to stdout."""
     from optopsy.ui._compat import import_optional_dependency
 
     import_optional_dependency("pyarrow")
@@ -33,6 +35,7 @@ def _cmd_cache_size(args: argparse.Namespace) -> None:
 
 
 def _cmd_cache_clear(args: argparse.Namespace) -> None:
+    """Delete cached parquet files, optionally filtered by symbol."""
     from optopsy.ui._compat import import_optional_dependency
 
     import_optional_dependency("pyarrow")
@@ -166,6 +169,7 @@ def _download_with_rich(provider: object, symbol: str) -> None:
 
 
 def _cmd_run(args: argparse.Namespace) -> None:
+    """Configure environment and launch the Chainlit server."""
     if args.host:
         os.environ["CHAINLIT_HOST"] = args.host
     if args.port:
@@ -213,6 +217,7 @@ def _cmd_run(args: argparse.Namespace) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
+    """Parse CLI arguments and dispatch to the appropriate subcommand."""
     parser = argparse.ArgumentParser(
         prog="optopsy-chat",
         description="Optopsy Chat — options strategy backtesting assistant",

--- a/optopsy/ui/providers/__init__.py
+++ b/optopsy/ui/providers/__init__.py
@@ -1,3 +1,16 @@
+"""Pluggable data provider registry.
+
+Providers are lazily imported so that ``import optopsy`` never requires UI
+extras (requests, pyarrow, etc.).  A provider is "available" when its
+``env_key`` (e.g. ``EODHD_API_KEY``) is set in the environment.
+
+Public helpers:
+
+- ``get_available_providers()`` — list providers with configured API keys
+- ``get_provider_for_tool(tool_name)`` — find the provider that handles a tool
+- ``get_all_provider_tool_schemas()`` — aggregate tool schemas for the LLM
+"""
+
 from typing import Any
 
 from .base import DataProvider

--- a/optopsy/ui/providers/cache.py
+++ b/optopsy/ui/providers/cache.py
@@ -1,3 +1,15 @@
+"""Parquet-based file cache for immutable historical market data.
+
+Each ``(category, symbol)`` pair maps to a single parquet file at
+``~/.optopsy/cache/{category}/{SYMBOL}.parquet``.  There is no TTL or
+eviction — historical data is immutable, so cached files are only ever
+appended to (via ``merge_and_save``) or explicitly cleared.
+
+The module also exports ``compute_date_gaps()``, which inspects a cached
+DataFrame and returns the date ranges that need to be fetched to fill
+coverage gaps (before, after, or interior holes).
+"""
+
 import logging
 import os
 from datetime import date, timedelta

--- a/optopsy/ui/providers/eodhd.py
+++ b/optopsy/ui/providers/eodhd.py
@@ -1,3 +1,20 @@
+"""EODHD data provider for historical US equity options chains.
+
+Implements the ``DataProvider`` interface to fetch options data from the
+EODHD Marketplace API.  Key features:
+
+- **Bulk download** (``download_options_data``) — fetches the complete
+  historical options chain for a symbol, split by option type and paginated
+  in ~30-day windows to stay within the 10K-offset API cap.  Supports
+  resumable downloads: only rows newer than the latest cached date are fetched.
+- **Local read** (``fetch_options_data``) — reads previously downloaded data
+  from the parquet cache and applies date/type/expiration filters.
+- **Rate limiting** — adaptive throttle based on ``X-RateLimit-Remaining``
+  header, with exponential backoff on 429 and 5xx errors.
+- **Progress callbacks** — ``download_with_progress()`` accepts callbacks for
+  Rich live-display integration in the CLI.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/optopsy/ui/tools/__init__.py
+++ b/optopsy/ui/tools/__init__.py
@@ -1,3 +1,12 @@
+"""Tool subsystem for the Optopsy Chat UI.
+
+Re-exports the main entry points used by ``OptopsyAgent``:
+
+- ``execute_tool()`` — dispatch a tool call by name and return a ``ToolResult``
+- ``get_tool_schemas()`` — generate OpenAI-compatible function schemas for all tools
+- Strategy, signal, and model registries used across the tool layer
+"""
+
 from ._executor import execute_tool
 from ._helpers import (
     _YF_CACHE_CATEGORY,

--- a/optopsy/ui/tools/_executor.py
+++ b/optopsy/ui/tools/_executor.py
@@ -1,3 +1,20 @@
+"""Tool handler implementations and main dispatcher.
+
+Each tool handler is registered via the ``@_register`` decorator and invoked
+by ``execute_tool()``.  Handlers receive the current session state (active
+dataset, named datasets, signals, results) and return a ``ToolResult`` that
+carries updated state back to the agent loop.
+
+Key handlers:
+
+- ``preview_data`` / ``describe_data`` — dataset inspection
+- ``run_strategy`` / ``scan_strategies`` — backtest execution
+- ``build_signal`` / ``preview_signal`` — TA signal construction
+- ``simulate`` / ``get_simulation_trades`` — chronological simulation
+- ``create_chart`` / ``plot_vol_surface`` — visualisation
+- ``compare_results`` / ``list_results`` — cross-run comparison
+"""
+
 import itertools as _itertools
 import json as _json
 import logging

--- a/optopsy/ui/tools/_helpers.py
+++ b/optopsy/ui/tools/_helpers.py
@@ -1,3 +1,15 @@
+"""Shared helper functions, data classes, and caches for tool handlers.
+
+Provides:
+
+- ``ToolResult`` — value object carrying LLM summary, user display, and
+  updated session state (dataset, signals, results) between tool calls.
+- DataFrame formatting utilities (``_df_to_markdown``, ``_df_summary``)
+- Signal resolution and stock data fetching for TA signals
+- Strategy result summary construction (``_make_result_summary``)
+- Simulation trade log persistence via ``ParquetCache``
+"""
+
 import logging
 import os
 import re

--- a/optopsy/ui/tools/_indicators.py
+++ b/optopsy/ui/tools/_indicators.py
@@ -76,6 +76,7 @@ def validate_indicator_columns(
 def add_sma_trace(
     fig: Any, go: Any, dates: pd.Series, close: pd.Series, ind: dict
 ) -> None:
+    """Add a Simple Moving Average line to the price panel."""
     period = ind.get("period", 20)
     fig.add_trace(
         go.Scatter(
@@ -92,6 +93,7 @@ def add_sma_trace(
 def add_ema_trace(
     fig: Any, go: Any, dates: pd.Series, close: pd.Series, ind: dict
 ) -> None:
+    """Add an Exponential Moving Average line to the price panel."""
     period = ind.get("period", 20)
     fig.add_trace(
         go.Scatter(
@@ -112,6 +114,7 @@ def add_bbands_traces(
     close: pd.Series,
     ind: dict,
 ) -> None:
+    """Add upper, lower, and middle Bollinger Band traces to the price panel."""
     period = ind.get("period", 20)
     std = ind.get("std", 2.0)
     bb = ta.bbands(close, length=period, std=std)
@@ -192,6 +195,7 @@ def add_rsi_traces(
     ind: dict,
     row: int,
 ) -> None:
+    """Add RSI line with overbought/oversold reference lines to a subplot row."""
     period = ind.get("period", 14)
     fig.add_trace(
         go.Scatter(
@@ -216,6 +220,7 @@ def add_macd_traces(
     ind: dict,
     row: int,
 ) -> None:
+    """Add MACD line, signal line, and histogram bar chart to a subplot row."""
     fast = ind.get("fast", 12)
     slow = ind.get("slow", 26)
     signal_period = ind.get("signal", 9)
@@ -252,6 +257,7 @@ def add_volume_traces(
     date_col: str,
     row: int,
 ) -> None:
+    """Add a volume bar chart colour-coded by price direction to a subplot row."""
     closes = sorted_df["close"]
     # Vectorised: green when close >= previous close (or first bar)
     vol_colors = (closes >= closes.shift(1).bfill()).map({True: "green", False: "red"})

--- a/optopsy/ui/tools/_models.py
+++ b/optopsy/ui/tools/_models.py
@@ -813,16 +813,24 @@ TOOL_ARG_MODELS: dict[str, type[BaseModel]] = {
 
 
 def _resolve_refs(schema: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
-    """Recursively resolve ``$ref`` pointers in a JSON schema."""
+    """Recursively resolve ``$ref`` pointers in a JSON schema.
+
+    Pydantic v2's ``model_json_schema()`` emits shared sub-models (enums,
+    nested BaseModels) as ``$defs`` entries referenced via ``$ref`` pointers.
+    OpenAI's function-calling schema format does not support ``$ref``, so this
+    function inlines every reference by walking the schema tree depth-first.
+    """
     if "$ref" in schema:
         ref_path = schema["$ref"]
-        # Handle "#/$defs/Foo" format
+        # Extract the definition name from "#/$defs/Foo" or "#/definitions/Foo"
         ref_name = ref_path.rsplit("/", 1)[-1]
         resolved = defs.get(ref_name, {})
+        # Recurse in case the resolved definition itself contains $ref pointers
         return _resolve_refs(dict(resolved), defs)
 
     result: dict[str, Any] = {}
     for key, value in schema.items():
+        # Drop the $defs / definitions block itself — its contents are inlined
         if key in ("$defs", "definitions"):
             continue
         if isinstance(value, dict):

--- a/optopsy/ui/tools/_schemas.py
+++ b/optopsy/ui/tools/_schemas.py
@@ -1,3 +1,13 @@
+"""Strategy, signal, and tool schema registries.
+
+This module is the single source of truth for:
+
+- ``STRATEGIES`` — maps strategy name to ``(function, description, is_calendar)``
+- ``SIGNAL_REGISTRY`` — maps signal name to a factory lambda returning a ``SignalFunc``
+- ``STRATEGY_OPTION_TYPE`` — maps strategy name to required option type for data fetching
+- ``get_tool_schemas()`` — generates OpenAI-compatible function schemas from Pydantic models
+"""
+
 import logging
 from typing import Any
 


### PR DESCRIPTION
## Summary
- Add module-level docstrings to 17 files across the core library and UI layer
- Add function/class docstrings to CLI commands, indicator trace builders, and the `OptopsyAgent` class
- Add inline comments to complex logic in `core.py` (slippage calculation, multi-leg strategy construction) and `_models.py` (`$ref` schema resolution)

## Test plan
- [x] `uv run python -c "import optopsy"` — import succeeds
- [x] `uv run pytest tests/ -v` — 555 passed, 12 skipped
- [x] `uv run ruff format --check optopsy/ tests/` — all files formatted
- [x] `uv run ruff check optopsy/ tests/` — all checks passed
- [x] `uv run mypy optopsy/` — passed via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)