### PR TITLE
feat: add multi-series charting to create_chart tool

### DIFF
--- a/optopsy/ui/agent.py
+++ b/optopsy/ui/agent.py
@@ -93,6 +93,19 @@ first to get the data, then `create_chart` with `chart_type: "candlestick"`.
 - If the user says they "have" data for a symbol, check the cache with `inspect_cache` first — \
 the data may already be downloaded.
 
+### Comparing results visually
+- After `scan_strategies` or multiple `run_strategy` calls, use `create_chart` with \
+`data_source: "results"` to chart all session results as a comparison. The results are assembled \
+into a multi-row DataFrame with columns like `strategy`, `mean_return`, `win_rate`, `profit_factor`.
+- Use `y_columns` to plot multiple metrics side-by-side: \
+`y_columns: ["mean_return", "win_rate"]` creates one trace per metric.
+- Use `group_by` to split data by a category: \
+`group_by: "strategy"` with `y: "mean_return"` creates one bar/line per strategy.
+- Use `bar_mode: "group"` (side-by-side, default) or `bar_mode: "stack"` for stacked bars.
+- Use `result_keys` to filter which results to include (omit to include all).
+- These multi-series params (`y_columns`, `group_by`, `bar_mode`) also work with \
+`data_source: "dataset"` or any other data source — not just results.
+
 ## Key Parameters (all optional)
 - max_entry_dte: Max days to expiration at entry (default 90)
 - exit_dte: DTE at exit (default 0, i.e. hold to expiration)

--- a/optopsy/ui/tools/_charts.py
+++ b/optopsy/ui/tools/_charts.py
@@ -9,9 +9,16 @@ from ._helpers import (
     _IV_COLUMN_MISSING_MSG,
     _YF_CACHE_CATEGORY,
     _filter_by_quote_date,
+    _select_results,
     _yf_cache,
     read_sim_trade_log,
 )
+
+# ---------------------------------------------------------------------------
+# Data source resolution
+# ---------------------------------------------------------------------------
+
+_DATA_SOURCE_NAMES = "dataset, result, results, simulation, signal, or stock"
 
 
 def _resolve_chart_data(
@@ -27,87 +34,116 @@ def _resolve_chart_data(
     Returns ``(df, source_label, error_msg)``.  When ``error_msg`` is not
     None the caller should return it as a tool result immediately.
     """
-    if data_source == "dataset":
-        ds_name = arguments.get("dataset_name")
-        df = _resolve_dataset(ds_name, dataset, datasets)
-        label = ds_name or "active dataset"
-        if df is None:
-            if ds_name and datasets:
-                return (
-                    None,
-                    label,
-                    (
-                        f"Dataset '{ds_name}' not found. "
-                        f"Available: {list(datasets.keys())}"
-                    ),
-                )
-            return None, label, "No dataset loaded. Load data first."
-        return df, label, None
+    resolver = _DATA_SOURCE_RESOLVERS.get(data_source)
+    if resolver is None:
+        return (
+            None,
+            "",
+            f"Unknown data_source '{data_source}'. Use: {_DATA_SOURCE_NAMES}.",
+        )
+    return resolver(arguments, dataset, datasets, results, signals)
 
-    if data_source == "result":
-        result_key = arguments.get("result_key")
-        if not result_key:
-            if not results:
-                return None, "", "No strategy results available. Run a strategy first."
-            result_key = list(results.keys())[-1]
-        entry = results.get(result_key)
-        if entry is None:
+
+def _resolve_ds_dataset(arguments, dataset, datasets, _results, _signals):
+    ds_name = arguments.get("dataset_name")
+    df = _resolve_dataset(ds_name, dataset, datasets)
+    label = ds_name or "active dataset"
+    if df is None:
+        if ds_name and datasets:
             return (
                 None,
-                result_key,
-                (f"Result '{result_key}' not found. Available: {list(results.keys())}"),
+                label,
+                f"Dataset '{ds_name}' not found. Available: {list(datasets.keys())}",
             )
-        return pd.DataFrame([entry]), result_key, None
+        return None, label, "No dataset loaded. Load data first."
+    return df, label, None
 
-    if data_source == "simulation":
-        sim_key = arguments.get("simulation_key")
-        if not sim_key:
-            sim_entries = [
-                k for k, v in results.items() if v.get("type") == "simulation"
-            ]
-            if not sim_entries:
-                return None, "", "No simulations run yet. Use simulate first."
-            sim_key = sim_entries[-1]
-        trade_log = read_sim_trade_log(sim_key)
-        if trade_log is None:
-            return None, sim_key, f"Simulation '{sim_key}' has no trade log data."
-        return trade_log, sim_key, None
 
-    if data_source == "signal":
-        slot = arguments.get("signal_slot")
-        if not slot or slot not in signals:
-            available = list(signals.keys()) if signals else []
-            return (
-                None,
-                f"signal:{slot}",
-                (
-                    f"Signal slot '{slot}' not found. "
-                    f"Available: {available or 'none — use build_signal first'}"
-                ),
-            )
-        return signals[slot], f"signal:{slot}", None
+def _resolve_ds_result(arguments, _dataset, _datasets, results, _signals):
+    result_key = arguments.get("result_key")
+    if not result_key:
+        if not results:
+            return None, "", "No strategy results available. Run a strategy first."
+        result_key = list(results.keys())[-1]
+    entry = results.get(result_key)
+    if entry is None:
+        return (
+            None,
+            result_key,
+            f"Result '{result_key}' not found. Available: {list(results.keys())}",
+        )
+    return pd.DataFrame([entry]), result_key, None
 
-    if data_source == "stock":
-        symbol = arguments.get("symbol", "").strip().upper()
-        if not symbol:
-            return None, "", "data_source='stock' requires a 'symbol' parameter."
-        cached = _yf_cache.read(_YF_CACHE_CATEGORY, symbol)
-        if cached is None or cached.empty:
-            return (
-                None,
-                f"stock:{symbol}",
-                (f"No cached stock data for {symbol}. Use fetch_stock_data first."),
-            )
-        return cached, f"stock:{symbol}", None
 
-    return (
-        None,
-        "",
-        (
-            f"Unknown data_source '{data_source}'. "
-            "Use: dataset, result, simulation, signal, or stock."
-        ),
-    )
+def _resolve_ds_results(arguments, _dataset, _datasets, results, _signals):
+    if not results:
+        return None, "", "No strategy results available. Run strategies first."
+    selected, sel_err = _select_results(results, arguments.get("result_keys"))
+    if sel_err:
+        return None, "results", sel_err
+    assert selected is not None
+    strat_entries = {k: v for k, v in selected.items() if v.get("type") != "simulation"}
+    if not strat_entries:
+        return None, "results", "No strategy results found (only simulations)."
+    rows = [{**entry, "result_key": key} for key, entry in strat_entries.items()]
+    return pd.DataFrame(rows), "results", None
+
+
+def _resolve_ds_simulation(arguments, _dataset, _datasets, results, _signals):
+    sim_key = arguments.get("simulation_key")
+    if not sim_key:
+        sim_entries = [k for k, v in results.items() if v.get("type") == "simulation"]
+        if not sim_entries:
+            return None, "", "No simulations run yet. Use simulate first."
+        sim_key = sim_entries[-1]
+    trade_log = read_sim_trade_log(sim_key)
+    if trade_log is None:
+        return None, sim_key, f"Simulation '{sim_key}' has no trade log data."
+    return trade_log, sim_key, None
+
+
+def _resolve_ds_signal(arguments, _dataset, _datasets, _results, signals):
+    slot = arguments.get("signal_slot")
+    if not slot or slot not in signals:
+        available = list(signals.keys()) if signals else []
+        return (
+            None,
+            f"signal:{slot}",
+            (
+                f"Signal slot '{slot}' not found. "
+                f"Available: {available or 'none — use build_signal first'}"
+            ),
+        )
+    return signals[slot], f"signal:{slot}", None
+
+
+def _resolve_ds_stock(arguments, _dataset, _datasets, _results, _signals):
+    symbol = arguments.get("symbol", "").strip().upper()
+    if not symbol:
+        return None, "", "data_source='stock' requires a 'symbol' parameter."
+    cached = _yf_cache.read(_YF_CACHE_CATEGORY, symbol)
+    if cached is None or cached.empty:
+        return (
+            None,
+            f"stock:{symbol}",
+            f"No cached stock data for {symbol}. Use fetch_stock_data first.",
+        )
+    return cached, f"stock:{symbol}", None
+
+
+_DATA_SOURCE_RESOLVERS = {
+    "dataset": _resolve_ds_dataset,
+    "result": _resolve_ds_result,
+    "results": _resolve_ds_results,
+    "simulation": _resolve_ds_simulation,
+    "signal": _resolve_ds_signal,
+    "stock": _resolve_ds_stock,
+}
+
+
+# ---------------------------------------------------------------------------
+# Column validation helpers
+# ---------------------------------------------------------------------------
 
 
 def _check_xy_columns(
@@ -117,6 +153,14 @@ def _check_xy_columns(
     if not x or not y:
         return f"{chart_type.title()} chart requires 'x' and 'y' column names."
     missing = [c for c in (x, y) if c not in df.columns]
+    if missing:
+        return f"Column(s) {missing} not found. Available: {list(df.columns)}"
+    return None
+
+
+def _validate_columns(df: pd.DataFrame, columns: list[str]) -> str | None:
+    """Return error message if any columns are missing from df, else None."""
+    missing = [c for c in columns if c not in df.columns]
     if missing:
         return f"Column(s) {missing} not found. Available: {list(df.columns)}"
     return None
@@ -145,6 +189,216 @@ def _resolve_candlestick_columns(
     return date_col, None
 
 
+# ---------------------------------------------------------------------------
+# Chart type builders — each returns (error_msg,) or None on success
+# ---------------------------------------------------------------------------
+
+
+def _build_multi_series(fig, go, df, arguments, x, y, color):
+    """Build line/bar/scatter traces with optional y_columns and group_by."""
+    chart_type = arguments["chart_type"]
+    y_columns = arguments.get("y_columns")
+    group_by_col = arguments.get("group_by")
+
+    if y_columns and y:
+        return "Provide either 'y' or 'y_columns', not both."
+
+    effective_y_list: list[str] = y_columns if y_columns else ([y] if y else [])
+
+    if not x:
+        return f"{chart_type.title()} chart requires an 'x' column name."
+    if not effective_y_list:
+        return f"{chart_type.title()} chart requires 'y' or 'y_columns'."
+
+    cols_to_check = [x] + effective_y_list
+    if group_by_col:
+        cols_to_check.append(group_by_col)
+    col_err = _validate_columns(df, cols_to_check)
+    if col_err:
+        return col_err
+
+    trace_builders = {
+        "line": lambda tx, ty, n, uc: go.Scatter(
+            x=tx,
+            y=ty,
+            mode="lines",
+            name=n,
+            line={"color": color} if uc and color else {},
+        ),
+        "bar": lambda tx, ty, n, uc: go.Bar(
+            x=tx,
+            y=ty,
+            name=n,
+            marker_color=color if uc else None,
+        ),
+        "scatter": lambda tx, ty, n, uc: go.Scatter(
+            x=tx,
+            y=ty,
+            mode="markers",
+            name=n,
+            marker={"color": color} if uc and color else {},
+        ),
+    }
+    build = trace_builders[chart_type]
+    single_trace = not group_by_col and len(effective_y_list) == 1
+
+    if group_by_col:
+        for group_name, group_df in df.groupby(group_by_col):
+            for y_col in effective_y_list:
+                name = (
+                    str(group_name)
+                    if len(effective_y_list) == 1
+                    else f"{group_name} — {y_col}"
+                )
+                fig.add_trace(build(group_df[x], group_df[y_col], name, False))
+    else:
+        for y_col in effective_y_list:
+            fig.add_trace(build(df[x], df[y_col], y_col, single_trace))
+    return None
+
+
+def _build_histogram(fig, go, df, arguments, x, y, color):
+    """Build a histogram trace."""
+    col = x or y
+    if not col:
+        return "Histogram requires 'x' (or 'y') column name."
+    col_err = _validate_columns(df, [col])
+    if col_err:
+        return col_err
+    hist_kwargs: dict[str, Any] = {"x": df[col], "name": col}
+    bins = arguments.get("bins")
+    if bins:
+        hist_kwargs["nbinsx"] = int(bins)
+    if color:
+        hist_kwargs["marker_color"] = color
+    fig.add_trace(go.Histogram(**hist_kwargs))
+    return None
+
+
+def _build_heatmap(fig, go, df, arguments, x, y, _color):
+    """Build a heatmap trace."""
+    heatmap_col = arguments.get("heatmap_col")
+    if not x or not y or not heatmap_col:
+        return "Heatmap requires 'x', 'y', and 'heatmap_col' column names."
+    col_err = _validate_columns(df, [x, y, heatmap_col])
+    if col_err:
+        return col_err
+    pivot = df.pivot_table(index=y, columns=x, values=heatmap_col, aggfunc="mean")
+    fig.add_trace(
+        go.Heatmap(
+            z=pivot.values,
+            x=[str(c) for c in pivot.columns],
+            y=[str(r) for r in pivot.index],
+            colorscale="RdYlGn",
+        )
+    )
+    return None
+
+
+def _build_indicators(fig, go, make_subplots, df, arguments, x, y, color):
+    """Build a candlestick or line chart with technical indicator overlays/subplots."""
+    from ._indicators import (
+        add_overlay_indicators,
+        add_subplot_indicators,
+        classify_indicators,
+        compute_figure_height,
+        compute_row_heights,
+        validate_indicator_columns,
+    )
+
+    chart_type = arguments["chart_type"]
+    indicators = arguments["indicators"]
+
+    if chart_type == "candlestick":
+        date_col, col_err = _resolve_candlestick_columns(df, x)
+        if col_err:
+            return col_err, None
+        assert date_col is not None
+    else:
+        col_err = _check_xy_columns(df, x, y, chart_type)
+        if col_err:
+            return col_err, None
+        assert x is not None
+        date_col = x
+
+    overlay_specs, subplot_specs, ind_err = classify_indicators(indicators)
+    if ind_err:
+        return ind_err, None
+
+    sorted_df = df.sort_values(date_col)
+    col_err = validate_indicator_columns(indicators, list(sorted_df.columns))
+    if col_err:
+        return col_err, None
+
+    n_subplot_panels = len(subplot_specs)
+    indicator_fig = make_subplots(
+        rows=1 + n_subplot_panels,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.03,
+        row_heights=compute_row_heights(n_subplot_panels),
+    )
+
+    if chart_type == "candlestick":
+        indicator_fig.add_trace(
+            go.Candlestick(
+                x=sorted_df[date_col],
+                open=sorted_df["open"],
+                high=sorted_df["high"],
+                low=sorted_df["low"],
+                close=sorted_df["close"],
+                name="Price",
+            ),
+            row=1,
+            col=1,
+        )
+    else:
+        indicator_fig.add_trace(
+            go.Scatter(
+                x=sorted_df[date_col],
+                y=sorted_df[y],
+                mode="lines",
+                name=y,
+                line={"color": color} if color else {},
+            ),
+            row=1,
+            col=1,
+        )
+
+    close = sorted_df["close"] if "close" in sorted_df.columns else None
+    add_overlay_indicators(indicator_fig, go, sorted_df[date_col], close, overlay_specs)
+    add_subplot_indicators(indicator_fig, go, sorted_df, date_col, close, subplot_specs)
+
+    height = arguments.get("figsize_height", compute_figure_height(n_subplot_panels))
+    indicator_fig.update_layout(xaxis_rangeslider_visible=False)
+    return None, (indicator_fig, height)
+
+
+def _build_candlestick(fig, go, df, arguments, x, _y, _color):
+    """Build a plain candlestick trace (no indicators)."""
+    date_col, col_err = _resolve_candlestick_columns(df, x)
+    if col_err:
+        return col_err
+    assert date_col is not None
+    sorted_df = df.sort_values(date_col)
+    fig.add_trace(
+        go.Candlestick(
+            x=sorted_df[date_col],
+            open=sorted_df["open"],
+            high=sorted_df["high"],
+            low=sorted_df["low"],
+            close=sorted_df["close"],
+        )
+    )
+    fig.update_layout(xaxis_rangeslider_visible=False)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main handler
+# ---------------------------------------------------------------------------
+
+
 @_register("create_chart")
 def _handle_create_chart(arguments, dataset, signals, datasets, results, _result):
     import plotly.graph_objects as go
@@ -168,179 +422,40 @@ def _handle_create_chart(arguments, dataset, signals, datasets, results, _result
 
     x = arguments.get("x")
     y = arguments.get("y")
-    heatmap_col = arguments.get("heatmap_col")
-    xlabel = arguments.get("xlabel", "")
-    ylabel = arguments.get("ylabel", "")
     color = arguments.get("color")
-    bins = arguments.get("bins")
     figsize_width = arguments.get("figsize_width", 800)
     figsize_height = arguments.get("figsize_height", 500)
 
     fig = go.Figure()
 
-    if chart_type in ("line", "bar", "scatter"):
-        col_err = _check_xy_columns(df, x, y, chart_type)
-        if col_err:
-            return _result(col_err)
-        if chart_type == "line":
-            fig.add_trace(
-                go.Scatter(
-                    x=df[x],
-                    y=df[y],
-                    mode="lines",
-                    name=y,
-                    line={"color": color} if color else {},
-                )
-            )
-        elif chart_type == "bar":
-            fig.add_trace(go.Bar(x=df[x], y=df[y], name=y, marker_color=color))
-        else:
-            fig.add_trace(
-                go.Scatter(
-                    x=df[x],
-                    y=df[y],
-                    mode="markers",
-                    name=y,
-                    marker={"color": color} if color else {},
-                )
-            )
+    # Dispatch to the appropriate builder
+    has_indicators = arguments.get("indicators")
+    if chart_type in ("candlestick", "line") and has_indicators:
+        result = _build_indicators(fig, go, make_subplots, df, arguments, x, y, color)
+        build_err, extra = result
+        if build_err:
+            return _result(build_err)
+        fig, figsize_height = extra
+
+    elif chart_type in ("line", "bar", "scatter"):
+        build_err = _build_multi_series(fig, go, df, arguments, x, y, color)
+        if build_err:
+            return _result(build_err)
 
     elif chart_type == "histogram":
-        col = x or y
-        if not col:
-            return _result("Histogram requires 'x' (or 'y') column name.")
-        if col not in df.columns:
-            return _result(f"Column '{col}' not found. Available: {list(df.columns)}")
-        hist_kwargs: dict[str, Any] = {"x": df[col], "name": col}
-        if bins:
-            hist_kwargs["nbinsx"] = int(bins)
-        if color:
-            hist_kwargs["marker_color"] = color
-        fig.add_trace(go.Histogram(**hist_kwargs))
+        build_err = _build_histogram(fig, go, df, arguments, x, y, color)
+        if build_err:
+            return _result(build_err)
 
     elif chart_type == "heatmap":
-        if not x or not y or not heatmap_col:
-            return _result("Heatmap requires 'x', 'y', and 'heatmap_col' column names.")
-        for col_name in (x, y, heatmap_col):
-            if col_name not in df.columns:
-                return _result(
-                    f"Column '{col_name}' not found. Available: {list(df.columns)}"
-                )
-        pivot = df.pivot_table(index=y, columns=x, values=heatmap_col, aggfunc="mean")
-        fig.add_trace(
-            go.Heatmap(
-                z=pivot.values,
-                x=[str(c) for c in pivot.columns],
-                y=[str(r) for r in pivot.index],
-                colorscale="RdYlGn",
-            )
-        )
-
-    elif chart_type in ("candlestick", "line") and arguments.get("indicators"):
-        # Multi-panel chart with indicators
-        from ._indicators import (
-            add_overlay_indicators,
-            add_subplot_indicators,
-            classify_indicators,
-            compute_figure_height,
-            compute_row_heights,
-            validate_indicator_columns,
-        )
-
-        indicators = arguments["indicators"]
-
-        # Validate price chart columns
-        if chart_type == "candlestick":
-            date_col, col_err = _resolve_candlestick_columns(df, x)
-            if col_err:
-                return _result(col_err)
-            assert date_col is not None
-        else:
-            col_err = _check_xy_columns(df, x, y, chart_type)
-            if col_err:
-                return _result(col_err)
-            assert x is not None
-            date_col = x
-
-        # Validate and classify indicators
-        overlay_specs, subplot_specs, ind_err = classify_indicators(indicators)
-        if ind_err:
-            return _result(ind_err)
-
-        sorted_df = df.sort_values(date_col)
-        col_err = validate_indicator_columns(indicators, list(sorted_df.columns))
-        if col_err:
-            return _result(col_err)
-
-        # Build multi-row subplot figure
-        n_subplot_panels = len(subplot_specs)
-        fig = make_subplots(
-            rows=1 + n_subplot_panels,
-            cols=1,
-            shared_xaxes=True,
-            vertical_spacing=0.03,
-            row_heights=compute_row_heights(n_subplot_panels),
-        )
-
-        # Price chart on row 1
-        if chart_type == "candlestick":
-            fig.add_trace(
-                go.Candlestick(
-                    x=sorted_df[date_col],
-                    open=sorted_df["open"],
-                    high=sorted_df["high"],
-                    low=sorted_df["low"],
-                    close=sorted_df["close"],
-                    name="Price",
-                ),
-                row=1,
-                col=1,
-            )
-        else:
-            fig.add_trace(
-                go.Scatter(
-                    x=sorted_df[date_col],
-                    y=sorted_df[y],
-                    mode="lines",
-                    name=y,
-                    line={"color": color} if color else {},
-                ),
-                row=1,
-                col=1,
-            )
-
-        close = sorted_df["close"] if "close" in sorted_df.columns else None
-        add_overlay_indicators(fig, go, sorted_df[date_col], close, overlay_specs)
-        add_subplot_indicators(
-            fig,
-            go,
-            sorted_df,
-            date_col,
-            close,
-            subplot_specs,
-        )
-
-        figsize_height = arguments.get(
-            "figsize_height", compute_figure_height(n_subplot_panels)
-        )
-        fig.update_layout(xaxis_rangeslider_visible=False)
+        build_err = _build_heatmap(fig, go, df, arguments, x, y, color)
+        if build_err:
+            return _result(build_err)
 
     elif chart_type == "candlestick":
-        date_col, col_err = _resolve_candlestick_columns(df, x)
-        if col_err:
-            return _result(col_err)
-        assert date_col is not None
-        sorted_df = df.sort_values(date_col)
-        fig.add_trace(
-            go.Candlestick(
-                x=sorted_df[date_col],
-                open=sorted_df["open"],
-                high=sorted_df["high"],
-                low=sorted_df["low"],
-                close=sorted_df["close"],
-            )
-        )
-        fig.update_layout(xaxis_rangeslider_visible=False)
+        build_err = _build_candlestick(fig, go, df, arguments, x, y, color)
+        if build_err:
+            return _result(build_err)
 
     else:
         return _result(
@@ -348,18 +463,27 @@ def _handle_create_chart(arguments, dataset, signals, datasets, results, _result
             "Use: line, bar, scatter, histogram, heatmap, or candlestick."
         )
 
-    fig.update_layout(
+    # Layout
+    xlabel = arguments.get("xlabel", "")
+    ylabel = arguments.get("ylabel", "")
+    multi_trace = len(fig.data) > 1
+    layout_kwargs: dict[str, Any] = dict(
         xaxis_title=xlabel or x or "",
         yaxis_title=ylabel or y or "",
         width=figsize_width,
         height=figsize_height,
         template="plotly_white",
-        showlegend=False,
+        showlegend=multi_trace,
         margin=dict(l=40, r=20, t=10, b=30),
     )
+    if chart_type == "bar" and multi_trace:
+        layout_kwargs["barmode"] = arguments.get("bar_mode", "group")
+    fig.update_layout(**layout_kwargs)
 
+    trace_info = f" {len(fig.data)} traces." if multi_trace else ""
     llm_summary = (
-        f"Created {chart_type} chart from {source_label}. {len(df)} data points."
+        f"Created {chart_type} chart from {source_label}. "
+        f"{len(df)} data points.{trace_info}"
     )
     return _result(llm_summary, user_display=llm_summary, chart_figure=fig)
 

--- a/optopsy/ui/tools/_helpers.py
+++ b/optopsy/ui/tools/_helpers.py
@@ -429,6 +429,25 @@ def _run_one_strategy(
         return None, str(e)
 
 
+def _select_results(
+    results: dict[str, dict],
+    result_keys: list[str] | None,
+) -> tuple[dict[str, dict] | None, str | None]:
+    """Select and validate results by key.
+
+    Returns ``(selected, error_msg)``.  When ``error_msg`` is not None,
+    the caller should surface it to the user.
+    """
+    if result_keys:
+        missing = [k for k in result_keys if k not in results]
+        if missing:
+            return None, (
+                f"Result key(s) not found: {missing}. Available: {list(results.keys())}"
+            )
+        return {k: results[k] for k in result_keys}, None
+    return dict(results), None
+
+
 def _make_result_key(strategy_name: str, arguments: dict) -> str:
     """Stable, human-readable key for a strategy run (used as results dict key).
 

--- a/optopsy/ui/tools/_models.py
+++ b/optopsy/ui/tools/_models.py
@@ -61,9 +61,15 @@ class ChartType(str, Enum):
 class DataSource(str, Enum):
     dataset = "dataset"
     result = "result"
+    results = "results"
     simulation = "simulation"
     signal = "signal"
     stock = "stock"
+
+
+class BarMode(str, Enum):
+    group = "group"
+    stack = "stack"
 
 
 class IndicatorType(str, Enum):
@@ -500,7 +506,9 @@ class CreateChartArgs(BaseModel):
         ...,
         description=(
             "Where to pull data from: 'dataset' (active or named "
-            "dataset), 'result' (strategy run summary from results registry), "
+            "dataset), 'result' (single strategy run summary), "
+            "'results' (all session results as a multi-row DataFrame "
+            "for comparison charting — use with result_keys to filter), "
             "'simulation' (trade log from a simulation run), "
             "'signal' (signal slot dates), "
             "'stock' (cached OHLCV stock data from fetch_stock_data)."
@@ -508,6 +516,30 @@ class CreateChartArgs(BaseModel):
     )
     x: str | None = Field(None, description="Column name for the x-axis.")
     y: str | None = Field(None, description="Column name for the y-axis.")
+    y_columns: list[str] | None = Field(
+        None,
+        description=(
+            "Multiple y-axis columns to plot as separate traces. "
+            "Use instead of 'y' when comparing metrics side by side. "
+            "Cannot be combined with 'y'."
+        ),
+    )
+    group_by: str | None = Field(
+        None,
+        description=(
+            "Column to group data by. Creates one trace per unique value. "
+            "For example, group_by='strategy' with x='max_entry_dte' and "
+            "y='mean_return' creates one bar per strategy per bucket."
+        ),
+    )
+    bar_mode: BarMode | None = Field(
+        None,
+        description=(
+            "Bar chart layout mode: 'group' (side by side, default) "
+            "or 'stack' (stacked). Only applies to bar charts with "
+            "multiple traces."
+        ),
+    )
     heatmap_col: str | None = Field(
         None,
         description=(
@@ -533,6 +565,13 @@ class CreateChartArgs(BaseModel):
         description=(
             "Key of a simulation to chart. Only used when "
             "data_source='simulation'. Omit for most recent."
+        ),
+    )
+    result_keys: list[str] | None = Field(
+        None,
+        description=(
+            "List of result keys to include when data_source='results'. "
+            "Omit to include all results in the session."
         ),
     )
     signal_slot: str | None = Field(

--- a/optopsy/ui/tools/_results_manager.py
+++ b/optopsy/ui/tools/_results_manager.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from ..providers.cache import ParquetCache
 from ._executor import _register
-from ._helpers import _df_to_markdown
+from ._helpers import _df_to_markdown, _select_results
 
 
 @_register("inspect_cache")
@@ -104,16 +104,10 @@ def _handle_compare_results(arguments, dataset, signals, datasets, results, _res
             "Use run_strategy or scan_strategies first, then compare_results."
         )
 
-    result_keys = arguments.get("result_keys")
-    if result_keys:
-        missing = [k for k in result_keys if k not in results]
-        if missing:
-            return _result(
-                f"Result key(s) not found: {missing}. Available: {list(results.keys())}"
-            )
-        selected = {k: results[k] for k in result_keys}
-    else:
-        selected = dict(results)
+    selected, sel_err = _select_results(results, arguments.get("result_keys"))
+    if sel_err:
+        return _result(sel_err)
+    assert selected is not None
 
     if len(selected) < 2:
         return _result(

--- a/optopsy/ui/tools/_schemas.py
+++ b/optopsy/ui/tools/_schemas.py
@@ -419,9 +419,11 @@ _TOOL_DESCRIPTIONS: dict[str, str] = {
     ),
     "create_chart": (
         "Create an interactive Plotly chart from strategy results, "
-        "simulation trade logs, datasets, or signals. Use this to "
-        "visualize equity curves, return distributions, strategy "
-        "comparisons, and heatmaps."
+        "simulation trade logs, datasets, or signals. Supports "
+        "multi-series charts via y_columns (multiple metrics) or "
+        "group_by (split by category). Use data_source='results' to "
+        "chart all session results as a comparison. Supports grouped "
+        "and stacked bar charts via bar_mode."
     ),
     "plot_vol_surface": (
         "Plot a volatility surface (heatmap of implied volatility by "

--- a/tests/test_tools_chart.py
+++ b/tests/test_tools_chart.py
@@ -735,3 +735,415 @@ class TestIndicatorCharts:
         assert result.chart_figure is not None
         assert len(result.chart_figure.data) == 1
         assert result.chart_figure.data[0].type == "candlestick"
+
+
+# ---------------------------------------------------------------------------
+# Multi-series chart tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tabular_data():
+    """Tabular data suitable for multi-series charting."""
+    return pd.DataFrame(
+        {
+            "strategy": ["long_calls", "long_calls", "long_puts", "long_puts"],
+            "dte_bucket": ["30", "60", "30", "60"],
+            "mean_return": [0.05, 0.08, -0.03, 0.02],
+            "win_rate": [0.6, 0.7, 0.4, 0.55],
+            "count": [10, 15, 8, 12],
+        }
+    )
+
+
+@pytest.fixture
+def multi_results():
+    """Multiple strategy results for data_source='results' tests."""
+    return {
+        "long_calls:dte=30": {
+            "strategy": "long_calls",
+            "max_entry_dte": 30,
+            "exit_dte": 0,
+            "max_otm_pct": 0.5,
+            "count": 10,
+            "mean_return": 0.05,
+            "std": 0.02,
+            "win_rate": 0.6,
+            "profit_factor": 1.5,
+        },
+        "long_puts:dte=30": {
+            "strategy": "long_puts",
+            "max_entry_dte": 30,
+            "exit_dte": 0,
+            "max_otm_pct": 0.5,
+            "count": 8,
+            "mean_return": -0.03,
+            "std": 0.04,
+            "win_rate": 0.4,
+            "profit_factor": 0.8,
+        },
+        "short_puts:dte=45": {
+            "strategy": "short_puts",
+            "max_entry_dte": 45,
+            "exit_dte": 0,
+            "max_otm_pct": 0.3,
+            "count": 20,
+            "mean_return": 0.02,
+            "std": 0.01,
+            "win_rate": 0.75,
+            "profit_factor": 2.0,
+        },
+    }
+
+
+class TestMultiSeriesCharts:
+    """Tests for y_columns, group_by, and bar_mode parameters."""
+
+    def test_bar_y_columns(self, tabular_data):
+        """Two y columns produce 2 bar traces."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strategy",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 2
+        assert result.chart_figure.data[0].type == "bar"
+        assert result.chart_figure.data[1].type == "bar"
+        names = {t.name for t in result.chart_figure.data}
+        assert names == {"mean_return", "win_rate"}
+
+    def test_line_y_columns(self, tabular_data):
+        """Two y columns produce 2 line traces."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "line",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 2
+        assert result.chart_figure.data[0].mode == "lines"
+
+    def test_scatter_y_columns(self, tabular_data):
+        """Two y columns produce 2 scatter traces."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "scatter",
+                "data_source": "dataset",
+                "x": "count",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 2
+        assert result.chart_figure.data[0].mode == "markers"
+
+    def test_y_and_y_columns_error(self, tabular_data):
+        """Providing both y and y_columns returns error."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strategy",
+                "y": "mean_return",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is None
+        assert "either" in result.llm_summary.lower()
+
+    def test_y_columns_missing_column(self, tabular_data):
+        """Invalid column in y_columns returns error."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strategy",
+                "y_columns": ["mean_return", "nonexistent"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is None
+        assert "not found" in result.llm_summary.lower()
+
+    def test_y_columns_legend_enabled(self, tabular_data):
+        """showlegend is True when multiple traces."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strategy",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert result.chart_figure.layout.showlegend is True
+
+    def test_bar_group_by(self, tabular_data):
+        """Group by strategy creates one trace per group."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y": "mean_return",
+                "group_by": "strategy",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        # 2 unique strategies = 2 traces
+        assert len(result.chart_figure.data) == 2
+        names = {t.name for t in result.chart_figure.data}
+        assert "long_calls" in names
+        assert "long_puts" in names
+
+    def test_line_group_by(self, tabular_data):
+        """Group by with line chart."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "line",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y": "mean_return",
+                "group_by": "strategy",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 2
+        assert result.chart_figure.data[0].mode == "lines"
+
+    def test_group_by_invalid_column(self, tabular_data):
+        """Nonexistent group_by column returns error."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y": "mean_return",
+                "group_by": "nonexistent",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is None
+        assert "nonexistent" in result.llm_summary.lower()
+
+    def test_group_by_with_y_columns(self, tabular_data):
+        """Combining group_by and y_columns multiplies traces."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y_columns": ["mean_return", "win_rate"],
+                "group_by": "strategy",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        # 2 strategies × 2 y_columns = 4 traces
+        assert len(result.chart_figure.data) == 4
+
+    def test_bar_mode_stack(self, tabular_data):
+        """bar_mode='stack' sets layout.barmode."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y_columns": ["mean_return", "win_rate"],
+                "bar_mode": "stack",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert result.chart_figure.layout.barmode == "stack"
+
+    def test_bar_mode_group(self, tabular_data):
+        """bar_mode='group' sets layout.barmode."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "dte_bucket",
+                "y_columns": ["mean_return", "win_rate"],
+                "bar_mode": "group",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert result.chart_figure.layout.barmode == "group"
+
+    def test_bar_mode_single_trace_ignored(self, tabular_data):
+        """barmode not set for single-trace bar chart."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            tabular_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 1
+        # barmode should not be set (defaults to None-ish)
+        assert result.chart_figure.layout.barmode in (None, "relative")
+
+    def test_single_y_backwards_compat(self, option_data):
+        """Existing single y/x still works with showlegend=False."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "dataset",
+                "x": "strike",
+                "y": "bid",
+            },
+            option_data,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 1
+        assert result.chart_figure.layout.showlegend is False
+
+
+class TestResultsDataSource:
+    """Tests for data_source='results'."""
+
+    def test_results_data_source(self, option_data, multi_results):
+        """Multiple results assembled into DataFrame, bar chart renders."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            option_data,
+            results=multi_results,
+        )
+        assert result.chart_figure is not None
+        assert result.chart_figure.data[0].type == "bar"
+
+    def test_results_with_keys_filter(self, option_data, multi_results):
+        """result_keys filters to subset."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "result_keys": ["long_calls:dte=30", "long_puts:dte=30"],
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            option_data,
+            results=multi_results,
+        )
+        assert result.chart_figure is not None
+        # Data should have 2 rows (filtered from 3)
+        assert "2 data points" in result.llm_summary
+
+    def test_results_missing_key(self, option_data, multi_results):
+        """Invalid key returns error."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "result_keys": ["nonexistent"],
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            option_data,
+            results=multi_results,
+        )
+        assert result.chart_figure is None
+        assert "not found" in result.llm_summary.lower()
+
+    def test_results_empty(self, option_data):
+        """No results returns error."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            option_data,
+            results={},
+        )
+        assert result.chart_figure is None
+        assert "no strategy results" in result.llm_summary.lower()
+
+    def test_results_with_y_columns(self, option_data, multi_results):
+        """Results data source with multiple y_columns."""
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "x": "result_key",
+                "y_columns": ["mean_return", "win_rate"],
+            },
+            option_data,
+            results=multi_results,
+        )
+        assert result.chart_figure is not None
+        assert len(result.chart_figure.data) == 2
+        assert result.chart_figure.layout.showlegend is True
+
+    def test_results_excludes_simulations(self, option_data):
+        """Simulation entries are excluded from results data source."""
+        results = {
+            "long_calls:dte=30": {
+                "strategy": "long_calls",
+                "count": 10,
+                "mean_return": 0.05,
+            },
+            "sim:long_calls": {
+                "type": "simulation",
+                "strategy": "long_calls",
+                "summary": {},
+            },
+        }
+        result = execute_tool(
+            "create_chart",
+            {
+                "chart_type": "bar",
+                "data_source": "results",
+                "x": "strategy",
+                "y": "mean_return",
+            },
+            option_data,
+            results=results,
+        )
+        assert result.chart_figure is not None
+        # Only 1 row (simulation excluded)
+        assert "1 data points" in result.llm_summary


### PR DESCRIPTION
## Summary
- Add `y_columns`, `group_by`, and `bar_mode` parameters to `create_chart` for multi-series line/bar/scatter charts
- Add `data_source="results"` to assemble all session strategy results into a chartable DataFrame (with optional `result_keys` filtering)
- Dynamic legend (auto-enabled for multi-trace) and `barmode` support for grouped/stacked bars
- Extract shared `_select_results()` helper to DRY up result-key selection between `_charts.py` and `_results_manager.py`
- Fully backwards-compatible — all 1082 existing tests pass unchanged

## Test plan
- [x] 20 new tests covering `y_columns`, `group_by`, `bar_mode`, `results` data source, error cases, and backwards compatibility
- [x] Full test suite passes (1082 tests)
- [x] Lint, format, and type checks pass (ruff, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)