### PR TITLE
fix: resolve Plotly chart persistence and resume rendering

### DIFF
--- a/optopsy/ui/app.py
+++ b/optopsy/ui/app.py
@@ -217,7 +217,7 @@ _storage_client = LocalStorageClient()
 async def _serve_storage_file(file_path: str):
     """Serve persisted element files (e.g. Plotly chart JSON) from local storage."""
     full_path = (STORAGE_DIR / file_path).resolve()
-    if not str(full_path).startswith(str(STORAGE_DIR.resolve())):
+    if not full_path.is_relative_to(STORAGE_DIR.resolve()):
         raise HTTPException(status_code=400, detail="Invalid path")
     if not full_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1335,7 +1335,7 @@ class TestDecodeBdata:
 
         from optopsy.ui.app import _decode_bdata
 
-        values = [50.0, 55.2, float("nan"), float("inf"), 48.3]
+        values = [50.0, 55.2, float("nan"), float("inf"), float("-inf"), 48.3]
         raw = struct.pack(f"<{len(values)}d", *values)
         encoded = base64.b64encode(raw).decode()
 
@@ -1355,8 +1355,9 @@ class TestDecodeBdata:
         assert y[0] == 50.0
         assert y[1] == 55.2
         assert y[2] is None  # was NaN
-        assert y[3] is None  # was Infinity
-        assert y[4] == 48.3
+        assert y[3] is None  # was +Infinity
+        assert y[4] is None  # was -Infinity
+        assert y[5] == 48.3
 
 
 class TestToolResultResultDf:


### PR DESCRIPTION
## Summary
- Fix storage route being shadowed by Chainlit's SPA catch-all (`/{full_path:path}`) by inserting it before the catch-all in FastAPI's route list
- Sniff extensionless chart files and serve as `application/json` so Chainlit's `useFetch` hook parses them correctly (instead of calling `.text()`)
- Decode Plotly's binary array encoding (`{dtype, bdata}`) to plain lists and sanitize `NaN`/`Infinity` to `null` for valid JSON that survives `JSON.parse` in the browser

## Test plan
- [x] Create a chart in a fresh conversation, verify it renders
- [x] Restart server, resume the thread — chart loads from storage
- [x] In the resumed session, ask for a chart with indicators (e.g. RSI) — renders without error
- [x] Restart server again, resume — both charts load correctly
- [x] All 1062 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)