### PR TITLE
feat: add build_custom_signal agent tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Branch names are enforced by a `pre-push` hook (via pre-commit). All branches mu
 | `hotfix/` | Urgent production fixes |
 | `release/` | Release preparation |
 | `claude/` | Claude-generated branches |
+| `copilot/` | Copilot-generated branches |
 | `main` | Main branch (no prefix) |
 
 Example: `feature/add-iron-condor-strategy`, `fix/dte-filter-bug`, `claude/refactor-core`

--- a/optopsy/ui/agent.py
+++ b/optopsy/ui/agent.py
@@ -215,7 +215,7 @@ results = op.long_calls(data, entry_dates=entry_dates, raw=True)
 **State-based** signals are True on every bar meeting the condition. \
 **Event-based** signals fire only on the crossover bar.
 
-### Using signals — two approaches
+### Using signals — three approaches
 
 **Approach 1: Inline (single signal)** — pass `entry_signal` / `exit_signal` directly on `run_strategy`. \
 Quick for single-condition filters.
@@ -235,6 +235,13 @@ Workflow:
 
 `entry_signal_slot` / `exit_signal_slot` **cannot** be combined with `entry_signal` / `exit_signal` — \
 pick one approach per side.
+
+**Approach 3: Custom signal (build_custom_signal)** — for conditions that no built-in \
+signal can express. Write pandas/numpy code computing a boolean Series `signal` from \
+OHLCV DataFrame `df` (columns: open, high, low, close, volume). Code runs per symbol. \
+Use for: gap ups/downs, volume spikes, price vs N-day high/low, custom indicator math. \
+The result is stored as a signal slot, just like build_signal, and can be referenced via \
+entry_signal_slot / exit_signal_slot.
 
 ### Signal data requirements
 

--- a/optopsy/ui/tools/_models.py
+++ b/optopsy/ui/tools/_models.py
@@ -440,6 +440,42 @@ class BuildSignalArgs(BaseModel):
     )
 
 
+class BuildCustomSignalArgs(BaseModel):
+    slot: str = Field(
+        ...,
+        description=(
+            "Name for this custom signal slot (e.g. 'gap_up', 'volume_spike'). "
+            "Used to reference the signal in run_strategy via entry_signal_slot / "
+            "exit_signal_slot."
+        ),
+    )
+    code: str = Field(
+        ...,
+        description=(
+            "Python code that computes a boolean Series named `signal` from an "
+            "OHLCV DataFrame `df`. Available columns: underlying_symbol, "
+            "quote_date, open, high, low, close, volume. Code runs per symbol "
+            "group with `pd` (pandas) and `np` (numpy) available.\n\n"
+            "Examples:\n"
+            "- Gap up 2%: signal = df['open'] > df['close'].shift(1) * 1.02\n"
+            "- Volume spike 3x 20d avg: signal = df['volume'] > df['volume'].rolling(20).mean() * 3\n"
+            "- Close crosses above 200-day high: signal = df['close'] > df['high'].rolling(200).max().shift(1)\n"
+            "- Inside day: signal = (df['high'] < df['high'].shift(1)) & (df['low'] > df['low'].shift(1))"
+        ),
+    )
+    description: str | None = Field(
+        None,
+        description="Human-readable description of the custom signal logic.",
+    )
+    dataset_name: str | None = Field(
+        None,
+        description=(
+            "Name (ticker or filename) of the dataset to build the signal from. "
+            "Omit to use the most-recently-loaded dataset."
+        ),
+    )
+
+
 class PreviewSignalArgs(BaseModel):
     slot: str = Field(..., description="Signal slot name to preview")
 
@@ -850,6 +886,7 @@ TOOL_ARG_MODELS: dict[str, type[BaseModel]] = {
     "run_strategy": RunStrategyArgs,
     "scan_strategies": ScanStrategiesArgs,
     "build_signal": BuildSignalArgs,
+    "build_custom_signal": BuildCustomSignalArgs,
     "preview_signal": PreviewSignalArgs,
     "list_signals": ListSignalsArgs,
     "list_results": ListResultsArgs,

--- a/optopsy/ui/tools/_schemas.py
+++ b/optopsy/ui/tools/_schemas.py
@@ -373,6 +373,13 @@ _TOOL_DESCRIPTIONS: dict[str, str] = {
         "strategies to get a clear comparison instead of describing "
         "differences in prose. Optionally includes a grouped bar chart."
     ),
+    "build_custom_signal": (
+        "Build a custom signal from arbitrary pandas/numpy code. Use when no "
+        "built-in signal matches the user's condition (gap ups, volume spikes, "
+        "price crossing N-day highs, etc.). Write Python code that computes a "
+        "boolean Series named `signal` from OHLCV DataFrame `df`. The result "
+        "is stored as a signal slot for use with run_strategy."
+    ),
     "build_signal": (
         "Build a TA signal (or compose multiple signals) and store the "
         "resulting valid dates under a named slot. Use this to create "

--- a/optopsy/ui/tools/_signals_builder.py
+++ b/optopsy/ui/tools/_signals_builder.py
@@ -157,6 +157,158 @@ def _handle_build_signal(arguments, dataset, signals, datasets, results, _result
     return _result(summary, user_display=display, sigs=updated_signals)
 
 
+@_register("build_custom_signal")
+def _handle_build_custom_signal(
+    arguments, dataset, signals, datasets, results, _result
+):
+    import numpy as np
+
+    slot = arguments.get("slot", "").strip()
+    if not slot:
+        return _result("Missing required 'slot' name for the signal.")
+    code = arguments.get("code", "").strip()
+    if not code:
+        return _result(
+            "Missing required 'code' — provide Python code that computes a boolean `signal` Series."
+        )
+
+    active_ds, _, err = _require_dataset(arguments, dataset, datasets, _result)
+    if err:
+        return err
+    assert active_ds is not None
+    dataset = active_ds
+
+    # Fetch OHLCV data for all symbols in the dataset
+    signal_data = _fetch_stock_data_for_signals(dataset)
+    if signal_data is None:
+        return _result(
+            "Custom signals require stock price data but yfinance is not "
+            "installed or the fetch failed. Install yfinance "
+            "(`pip install yfinance`) and try again.",
+        )
+
+    # Restricted builtins — block import, open, exec, eval, compile, etc.
+    _SAFE_BUILTINS = {
+        "abs": abs,
+        "all": all,
+        "any": any,
+        "bool": bool,
+        "dict": dict,
+        "enumerate": enumerate,
+        "filter": filter,
+        "float": float,
+        "int": int,
+        "isinstance": isinstance,
+        "len": len,
+        "list": list,
+        "map": map,
+        "max": max,
+        "min": min,
+        "print": print,
+        "range": range,
+        "round": round,
+        "set": set,
+        "sorted": sorted,
+        "str": str,
+        "sum": sum,
+        "tuple": tuple,
+        "type": type,
+        "zip": zip,
+        "True": True,
+        "False": False,
+        "None": None,
+    }
+
+    flagged_frames = []
+    symbols = signal_data["underlying_symbol"].unique()
+    errors = []
+
+    for sym in symbols:
+        sym_df = signal_data[signal_data["underlying_symbol"] == sym].copy()
+        sym_df = sym_df.sort_values("quote_date").reset_index(drop=True)
+
+        exec_globals = {
+            "__builtins__": _SAFE_BUILTINS,
+            "pd": pd,
+            "np": np,
+            "df": sym_df,
+        }
+        exec_locals: dict = {}
+
+        try:
+            exec(code, exec_globals, exec_locals)  # noqa: S102
+        except Exception as exc:
+            errors.append(f"{sym}: {type(exc).__name__}: {exc}")
+            continue
+
+        sig = exec_locals.get("signal")
+        if sig is None:
+            # Also check exec_globals in case user wrote `signal = ...` at top level
+            sig = exec_globals.get("signal")
+        if sig is None:
+            errors.append(
+                f"{sym}: Code did not produce a variable named `signal`. "
+                "Your code must assign a boolean Series to `signal`."
+            )
+            continue
+
+        if not isinstance(sig, pd.Series):
+            errors.append(
+                f"{sym}: `signal` must be a pandas Series, got {type(sig).__name__}."
+            )
+            continue
+
+        # Coerce to bool, filling NaN with False
+        sig = sig.fillna(False).astype(bool)
+
+        flagged = sym_df.loc[sig, ["underlying_symbol", "quote_date"]].copy()
+        if not flagged.empty:
+            flagged_frames.append(flagged)
+
+    if errors:
+        error_detail = "\n".join(errors)
+        return _result(
+            f"Custom signal code failed:\n{error_detail}\n\n"
+            "Fix the code and try again. The code must assign a boolean "
+            "Series named `signal` from DataFrame `df`."
+        )
+
+    if not flagged_frames:
+        combined = pd.DataFrame(columns=["underlying_symbol", "quote_date"])
+    else:
+        combined = pd.concat(flagged_frames, ignore_index=True)
+
+    # Intersect with options dates
+    valid_dates = _intersect_with_options_dates(combined, dataset)
+
+    # Store in signals dict
+    updated_signals = dict(signals)
+    updated_signals[slot] = valid_dates
+
+    desc = arguments.get("description") or "custom code"
+    n_dates, syms, date_min, date_max = _signal_slot_summary(valid_dates)
+    summary = f"Signal '{slot}' built: {desc} → {n_dates} valid dates for {syms}"
+    display_lines = [summary]
+    if n_dates > 0:
+        display_lines.append(f"Date range: {date_min} to {date_max}")
+    else:
+        opt_min = dataset["quote_date"].min().date()
+        opt_max = dataset["quote_date"].max().date()
+        if combined.empty:
+            display_lines.append(
+                "WARNING: The custom signal never triggered for any symbol. "
+                "Check your code logic or try different conditions."
+            )
+        else:
+            suggestion = _empty_signal_suggestion(combined, opt_min, opt_max)
+            display_lines.append(
+                f"WARNING: No signal dates overlap the options data "
+                f"({opt_min} to {opt_max}). {suggestion}"
+            )
+    display = "\n".join(display_lines)
+    return _result(summary, user_display=display, sigs=updated_signals)
+
+
 @_register("preview_signal")
 def _handle_preview_signal(arguments, dataset, signals, datasets, results, _result):
     slot = arguments.get("slot", "").strip()

--- a/scripts/check-branch-name.sh
+++ b/scripts/check-branch-name.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 
-if ! echo "$branch" | grep -qE "^(feature|fix|bugfix|hotfix|release|claude)/|^main$"; then
+if ! echo "$branch" | grep -qE "^(feature|fix|bugfix|hotfix|release|claude|copilot)/|^main$"; then
     echo "ERROR: Branch \"$branch\" does not follow naming convention."
-    echo "Allowed prefixes: feature/, fix/, bugfix/, hotfix/, release/, claude/"
+    echo "Allowed prefixes: feature/, fix/, bugfix/, hotfix/, release/, claude/, copilot/"
     echo "Example: feature/add-new-strategy"
     exit 1
 fi

--- a/tests/test_tools_custom_signal.py
+++ b/tests/test_tools_custom_signal.py
@@ -1,0 +1,344 @@
+"""Tests for the build_custom_signal tool handler."""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("pyarrow", reason="UI extras not installed")
+
+from optopsy.ui.tools import execute_tool
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_OPTIONS_DATES = ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"]
+_STOCK_DATES = ["2023-12-01", "2023-12-04"] + _OPTIONS_DATES
+
+
+def _make_options(symbol="SPY"):
+    """Minimal options DataFrame for intersection tests."""
+    rows = []
+    for d in _OPTIONS_DATES:
+        rows.append(
+            {
+                "underlying_symbol": symbol,
+                "underlying_price": 470.0,
+                "option_type": "c",
+                "expiration": pd.Timestamp("2024-02-16"),
+                "quote_date": pd.Timestamp(d),
+                "strike": 470.0,
+                "bid": 5.0,
+                "ask": 5.5,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _make_stock(symbol="SPY"):
+    """OHLCV stock data that overlaps the options dates."""
+    dates = pd.to_datetime(_STOCK_DATES)
+    n = len(dates)
+    return pd.DataFrame(
+        {
+            "underlying_symbol": [symbol] * n,
+            "quote_date": dates,
+            "open": [468.0, 469.0, 470.0, 471.0, 472.0, 473.0],
+            "high": [469.5, 470.5, 472.0, 473.0, 474.0, 475.0],
+            "low": [467.0, 468.0, 469.0, 470.0, 471.0, 472.0],
+            "close": [469.0, 470.0, 471.0, 472.0, 473.0, 474.0],
+            "volume": [1_000_000, 1_100_000, 900_000, 5_000_000, 800_000, 1_200_000],
+        }
+    )
+
+
+@pytest.fixture
+def options():
+    return _make_options()
+
+
+@pytest.fixture
+def stock():
+    return _make_stock()
+
+
+def _run(code, options, stock, slot="test", description=None):
+    """Helper to call build_custom_signal with mocked stock data."""
+    args = {"slot": slot, "code": code}
+    if description:
+        args["description"] = description
+    with patch(
+        "optopsy.ui.tools._signals_builder._fetch_stock_data_for_signals",
+        return_value=stock,
+    ):
+        return execute_tool("build_custom_signal", args, options)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalHappyPath:
+    def test_simple_code_produces_correct_signal_dates(self, options, stock):
+        """Simple close > 471 should flag dates where close exceeds 471."""
+        result = _run("signal = df['close'] > 471", options, stock)
+        assert "failed" not in result.llm_summary.lower()
+        assert result.signals is not None
+        assert "test" in result.signals
+        valid = result.signals["test"]
+        # close values: [469, 470, 471, 472, 473, 474]
+        # options dates: [Jan 2, 3, 4, 5]
+        # close > 471 on stock dates: Jan 3 (472), Jan 4 (473), Jan 5 (474)
+        # Intersection with options: Jan 3, 4, 5
+        assert len(valid) == 3
+
+    def test_rolling_window_volume_spike(self, options, stock):
+        """Volume > 2x rolling mean should catch the spike on 2024-01-05."""
+        code = "signal = df['volume'] > df['volume'].rolling(3).mean() * 2"
+        result = _run(code, options, stock)
+        assert "failed" not in result.llm_summary.lower()
+        assert result.signals is not None
+        valid = result.signals["test"]
+        # volumes: [1M, 1.1M, 0.9M, 5M, 0.8M, 1.2M]
+        # rolling(3).mean at idx 3 = (0.9+1.1+1.0)/3 = 1.0M, 5M > 2M → True
+        # rolling(3).mean at idx 4 = (5+0.9+1.1)/3 ≈ 2.33M, 0.8M > 4.67M → False
+        # rolling(3).mean at idx 5 = (0.8+5+0.9)/3 ≈ 2.23M, 1.2M > 4.47M → False
+        # So only Jan 5 (idx 3 = options idx for Jan 5) should flag
+        assert len(valid) >= 1
+
+    def test_description_appears_in_summary(self, options, stock):
+        """The description field should appear in the result summary."""
+        result = _run(
+            "signal = df['close'] > 471",
+            options,
+            stock,
+            description="close above 471",
+        )
+        assert "close above 471" in result.llm_summary
+
+    def test_signal_stored_in_slot(self, options, stock):
+        """The signal slot should be stored and retrievable."""
+        result = _run("signal = df['close'] > 0", options, stock, slot="my_entry")
+        assert "my_entry" in result.signals
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalErrors:
+    def test_missing_signal_variable(self, options, stock):
+        """Code that doesn't produce `signal` should return clear error."""
+        result = _run("x = df['close'] > 471", options, stock)
+        assert "signal" in result.llm_summary.lower()
+        assert (
+            "failed" in result.llm_summary.lower()
+            or "did not produce" in result.llm_summary.lower()
+        )
+
+    def test_syntax_error(self, options, stock):
+        """Code with syntax errors should return descriptive error."""
+        result = _run("signal = df['close' > 471", options, stock)
+        assert (
+            "SyntaxError" in result.llm_summary
+            or "failed" in result.llm_summary.lower()
+        )
+
+    def test_runtime_error(self, options, stock):
+        """Code that raises at runtime should return descriptive error."""
+        result = _run("signal = df['nonexistent_column'] > 0", options, stock)
+        assert (
+            "KeyError" in result.llm_summary or "failed" in result.llm_summary.lower()
+        )
+
+    def test_wrong_type_for_signal(self, options, stock):
+        """If `signal` is not a Series, return type error."""
+        result = _run("signal = 42", options, stock)
+        assert "Series" in result.llm_summary or "type" in result.llm_summary.lower()
+
+    def test_nan_handled_as_false(self, options, stock):
+        """NaN values in signal should be treated as False, not cause errors."""
+        # shift(1) produces NaN for first row
+        code = "signal = df['close'] > df['close'].shift(1)"
+        result = _run(code, options, stock)
+        assert "failed" not in result.llm_summary.lower()
+
+    def test_no_dataset_loaded(self):
+        """Should error when no dataset is loaded."""
+        result = execute_tool(
+            "build_custom_signal", {"slot": "x", "code": "signal = True"}, None
+        )
+        assert (
+            "no dataset" in result.llm_summary.lower()
+            or "load data" in result.llm_summary.lower()
+        )
+
+    def test_missing_slot(self, options, stock):
+        """Missing slot name should error."""
+        result = _run("signal = df['close'] > 0", options, stock, slot="")
+        # slot="" triggers strip → empty → error
+        with patch(
+            "optopsy.ui.tools._signals_builder._fetch_stock_data_for_signals",
+            return_value=stock,
+        ):
+            result = execute_tool(
+                "build_custom_signal", {"slot": "", "code": "signal = True"}, options
+            )
+        assert (
+            "slot" in result.llm_summary.lower()
+            or "missing" in result.llm_summary.lower()
+        )
+
+    def test_missing_code(self, options, stock):
+        """Missing code should error."""
+        with patch(
+            "optopsy.ui.tools._signals_builder._fetch_stock_data_for_signals",
+            return_value=stock,
+        ):
+            result = execute_tool(
+                "build_custom_signal", {"slot": "x", "code": ""}, options
+            )
+        assert (
+            "code" in result.llm_summary.lower()
+            or "missing" in result.llm_summary.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sandbox restrictions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalSandbox:
+    def test_import_blocked(self, options, stock):
+        """import statements should fail in the sandbox."""
+        result = _run("import os; signal = df['close'] > 0", options, stock)
+        assert "failed" in result.llm_summary.lower()
+
+    def test_open_blocked(self, options, stock):
+        """open() should not be available."""
+        result = _run(
+            "f = open('/etc/passwd'); signal = df['close'] > 0", options, stock
+        )
+        assert "failed" in result.llm_summary.lower()
+
+    def test_dunder_import_blocked(self, options, stock):
+        """__import__ should not be available."""
+        result = _run("__import__('os'); signal = df['close'] > 0", options, stock)
+        assert "failed" in result.llm_summary.lower()
+
+    def test_exec_blocked(self, options, stock):
+        """exec() should not be available in the sandbox."""
+        result = _run("exec('x=1'); signal = df['close'] > 0", options, stock)
+        assert "failed" in result.llm_summary.lower()
+
+    def test_eval_blocked(self, options, stock):
+        """eval() should not be available in the sandbox."""
+        result = _run("eval('1+1'); signal = df['close'] > 0", options, stock)
+        assert "failed" in result.llm_summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Multi-symbol
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalMultiSymbol:
+    def test_code_runs_per_symbol_independently(self):
+        """Code should run per-symbol, not on the entire DataFrame."""
+        # Create two symbols with different data
+        opts_spy = _make_options("SPY")
+        opts_aapl = _make_options("AAPL")
+        options = pd.concat([opts_spy, opts_aapl], ignore_index=True)
+
+        stock_spy = _make_stock("SPY")
+        stock_aapl = _make_stock("AAPL")
+        stock = pd.concat([stock_spy, stock_aapl], ignore_index=True)
+
+        # Use len(df) in signal — if code ran on full df it would have more rows
+        result = _run("signal = df['close'] > 471", options, stock)
+        assert "failed" not in result.llm_summary.lower()
+        valid = result.signals["test"]
+        # Each symbol should independently flag close > 471
+        symbols = valid["underlying_symbol"].unique().tolist()
+        assert "SPY" in symbols
+        assert "AAPL" in symbols
+
+
+# ---------------------------------------------------------------------------
+# Empty result / options date intersection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalEmptyResult:
+    def test_no_signal_fires(self, options, stock):
+        """When signal is always False, should get warning."""
+        result = _run("signal = df['close'] > 99999", options, stock)
+        assert (
+            "WARNING" in result.user_display
+            or "never triggered" in result.user_display.lower()
+        )
+        assert result.signals["test"].empty
+
+    def test_empty_after_options_intersection(self, options):
+        """Signal fires only on dates outside options range → warning."""
+        # Stock data only has pre-options dates
+        stock = pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY"] * 3,
+                "quote_date": pd.to_datetime(
+                    ["2023-06-01", "2023-06-02", "2023-06-03"]
+                ),
+                "open": [400.0, 401.0, 402.0],
+                "high": [401.0, 402.0, 403.0],
+                "low": [399.0, 400.0, 401.0],
+                "close": [400.5, 401.5, 402.5],
+                "volume": [1_000_000] * 3,
+            }
+        )
+        result = _run("signal = df['close'] > 0", options, stock)
+        assert "0 valid dates" in result.llm_summary or result.signals["test"].empty
+
+
+# ---------------------------------------------------------------------------
+# Integration with preview_signal and list_signals
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCustomSignalIntegration:
+    def test_slot_works_with_preview_signal(self, options, stock):
+        """After build_custom_signal, preview_signal should show the slot."""
+        build_result = _run(
+            "signal = df['close'] > 471", options, stock, slot="custom1"
+        )
+        signals = build_result.signals
+
+        preview_result = execute_tool(
+            "preview_signal",
+            {"slot": "custom1"},
+            options,
+            signals=signals,
+        )
+        assert "custom1" in preview_result.llm_summary
+        assert (
+            "valid dates" in preview_result.llm_summary.lower()
+            or "0" not in preview_result.llm_summary
+        )
+
+    def test_slot_works_with_list_signals(self, options, stock):
+        """After build_custom_signal, list_signals should include the slot."""
+        build_result = _run(
+            "signal = df['close'] > 471", options, stock, slot="custom2"
+        )
+        signals = build_result.signals
+
+        list_result = execute_tool(
+            "list_signals",
+            {},
+            options,
+            signals=signals,
+        )
+        assert "custom2" in list_result.llm_summary

--- a/tests/test_tools_models.py
+++ b/tests/test_tools_models.py
@@ -324,6 +324,7 @@ class TestSchemaGeneration:
             "run_strategy",
             "scan_strategies",
             "build_signal",
+            "build_custom_signal",
             "preview_signal",
             "list_signals",
             "list_results",


### PR DESCRIPTION
## Summary

- Add `build_custom_signal` tool that lets users define custom entry/exit signals via arbitrary pandas/numpy code (e.g. gap ups, volume spikes, rolling high crossovers)
- Code executes in a restricted `exec()` sandbox per symbol group — only `pd`, `np`, `df`, and safe builtins are available (no `import`, `open`, `eval`, `exec`, `__import__`)
- Results are intersected with options dates and stored as a signal slot, compatible with `preview_signal`, `list_signals`, and `run_strategy` via `entry_signal_slot`/`exit_signal_slot`
- Also adds `copilot/` branch prefix to branch naming convention

## Test plan

- [x] 22 new tests in `tests/test_tools_custom_signal.py` covering:
  - Happy path (simple code, rolling windows, descriptions, slot storage)
  - Error handling (missing `signal` var, syntax/runtime errors, wrong type, NaN, no dataset, missing slot/code)
  - Sandbox restrictions (`import`, `open()`, `__import__`, `exec()`, `eval()` blocked)
  - Multi-symbol (code runs per-symbol independently)
  - Empty results (never triggers, no options date overlap)
  - Integration with `preview_signal` and `list_signals`
- [x] All 1120 tests pass (full suite)
- [x] ruff format + ruff check clean
- [x] ty type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)