### PR TITLE
Apply slippage model to stock-backed covered strategies

### DIFF
--- a/optopsy/strategies/_helpers.py
+++ b/optopsy/strategies/_helpers.py
@@ -32,7 +32,7 @@ from ..definitions import (
 )
 from ..evaluation import _evaluate_all_options
 from ..output import _format_output
-from ..pricing import _calculate_commission
+from ..pricing import _calculate_commission, _calculate_fill_price
 from ..rules import (
     _rule_butterfly_strikes,
     _rule_expiration_ordering,
@@ -375,6 +375,36 @@ def _covered_with_stock(
 
     if result.empty:
         return _empty_result()
+
+    # --- apply slippage to option leg ---
+    slippage = params["slippage"]
+    has_bid_ask = "bid_entry" in result.columns and "ask_entry" in result.columns
+    if has_bid_ask and slippage != "mid":
+        result = result.copy()
+        volume_entry = (
+            result.get("volume_entry") if "volume_entry" in result.columns else None
+        )
+        result["entry"] = _calculate_fill_price(
+            result["bid_entry"],
+            result["ask_entry"],
+            option_side.value,
+            slippage,
+            params["fill_ratio"],
+            volume_entry,
+            params["reference_volume"],
+        )
+        volume_exit = (
+            result.get("volume_exit") if "volume_exit" in result.columns else None
+        )
+        result["exit"] = _calculate_fill_price(
+            result["bid_exit"],
+            result["ask_exit"],
+            -option_side.value,
+            slippage,
+            params["fill_ratio"],
+            volume_exit,
+            params["reference_volume"],
+        )
 
     # --- compute combined P&L ---
     stock_entry = result["_stock_entry"]

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1199,6 +1199,73 @@ def test_slippage_calendar_spread_mode(calendar_data):
     )
 
 
+def test_slippage_covered_call_with_stock(multi_strike_data, stock_data_multi_strike):
+    """Test that slippage is applied to the option leg in stock-backed covered calls."""
+    results_mid = covered_call(
+        multi_strike_data, stock_data=stock_data_multi_strike, raw=True, slippage="mid"
+    )
+    results_spread = covered_call(
+        multi_strike_data,
+        stock_data=stock_data_multi_strike,
+        raw=True,
+        slippage="spread",
+    )
+
+    assert not results_mid.empty
+    assert not results_spread.empty
+
+    row_mid = results_mid.iloc[0]
+    row_spread = results_spread.iloc[0]
+
+    # Stock prices are identical (close prices, no bid/ask)
+    assert row_mid["strike_leg1"] == row_spread["strike_leg1"]
+
+    # Covered call = long stock + short call.
+    # Short call entry fills at bid (worse for seller) under spread slippage,
+    # so option premium received is lower -> total entry cost is higher.
+    assert row_spread["total_entry_cost"] > row_mid["total_entry_cost"]
+
+    # Verify exact values:
+    # Short call at 215.0: bid=1.50, ask=1.60, mid=1.55
+    # Mid mode: entry = stock(212.5) - mid(1.55) = 210.95
+    assert round(row_mid["total_entry_cost"], 2) == 210.95
+    # Spread mode: short entry fills at bid=1.50
+    # entry = stock(212.5) - bid(1.50) = 211.00
+    assert round(row_spread["total_entry_cost"], 2) == 211.00
+
+
+def test_slippage_protective_put_with_stock(multi_strike_data, stock_data_multi_strike):
+    """Test that slippage is applied to the option leg in stock-backed protective puts."""
+    results_mid = protective_put(
+        multi_strike_data, stock_data=stock_data_multi_strike, raw=True, slippage="mid"
+    )
+    results_spread = protective_put(
+        multi_strike_data,
+        stock_data=stock_data_multi_strike,
+        raw=True,
+        slippage="spread",
+    )
+
+    assert not results_mid.empty
+    assert not results_spread.empty
+
+    row_mid = results_mid.iloc[0]
+    row_spread = results_spread.iloc[0]
+
+    # Protective put = long stock + long put.
+    # Long put entry fills at ask (worse for buyer) under spread slippage,
+    # so total entry cost is higher.
+    assert row_spread["total_entry_cost"] > row_mid["total_entry_cost"]
+
+    # Verify exact values:
+    # Long put at 210.0: bid=1.40, ask=1.50, mid=1.45
+    # Mid mode: entry = stock(212.5) + mid(1.45) = 213.95
+    assert round(row_mid["total_entry_cost"], 2) == 213.95
+    # Spread mode: long entry fills at ask=1.50
+    # entry = stock(212.5) + ask(1.50) = 214.00
+    assert round(row_spread["total_entry_cost"], 2) == 214.00
+
+
 # =============================================================================
 # Empty DataFrame Edge Cases
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixes #186: `_covered_with_stock()` now applies the `slippage`, `fill_ratio`, and `reference_volume` parameters to the option leg via `_calculate_fill_price()`, matching the behavior of `_strategy_engine()` and `_calculate_calendar_pnl()`
- Previously these parameters were silently ignored, always using midpoint pricing for the option leg in stock-backed covered calls and protective puts
- Adds tests verifying exact fill prices for both covered calls (short option) and protective puts (long option) under spread slippage

## Test plan
- [x] `test_slippage_covered_call_with_stock` — short call fills at bid under spread slippage
- [x] `test_slippage_protective_put_with_stock` — long put fills at ask under spread slippage
- [x] Full test suite passes (1037 passed, 0 failed)
- [x] Ruff lint and type checks pass