### PR TITLE
Update MkDocs theme colors for cohesive palette

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,14 @@
-:root {
-  --md-primary-fg-color: hsl(201, 19.3%, 23.3%);
-  --md-primary-fg-color--light: hsl(201, 19.3%, 35%);
-  --md-primary-fg-color--dark: hsl(201, 19.3%, 18%);
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #374851;
+  --md-primary-fg-color--light: #4a5d68;
+  --md-primary-fg-color--dark: #2a373e;
   --md-accent-fg-color: hsl(201, 19.3%, 45%);
+  --md-default-bg-color: #eaebe5;
+  --md-default-bg-color--light: #eaebe5;
+  --md-default-bg-color--dark: #e2e3dd;
+  --md-default-fg-color: #374851;
+  --md-default-fg-color--light: #4a5d68;
+  --md-default-fg-color--lightest: #6b7d87;
+  --md-typeset-color: #374851;
+  --md-code-bg-color: #f5f6f1;
 }


### PR DESCRIPTION
## Summary
- Set page background to `#eaebe5` and text/banner color to `#374851`
- Added code block background `#f5f6f1` with warm undertone to blend with the page background
- Fixed CSS specificity by using `[data-md-color-scheme="default"]` selector instead of `:root`

## Test plan
- [ ] Verify background, text, and banner colors render correctly
- [ ] Verify code blocks have warm-toned background that blends with page
- [ ] Check docs deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)