### PR TITLE
Make underlying_price optional in the strategy pipeline

### DIFF
--- a/optopsy/calendar.py
+++ b/optopsy/calendar.py
@@ -67,17 +67,17 @@ def _prepare_calendar_leg(
     strike_col = _get_strike_column(same_strike, leg_num)
     price_col = "underlying_price_entry" if leg_num == 1 else "underlying_price_back"
 
-    return options.rename(
-        columns={
-            "expiration": f"expiration_leg{leg_num}",
-            "dte": f"dte_entry_leg{leg_num}",
-            "strike": strike_col,
-            "bid": f"bid_leg{leg_num}",
-            "ask": f"ask_leg{leg_num}",
-            "delta": f"delta_leg{leg_num}",
-            "underlying_price": price_col,
-        }
-    )
+    rename_map = {
+        "expiration": f"expiration_leg{leg_num}",
+        "dte": f"dte_entry_leg{leg_num}",
+        "strike": strike_col,
+        "bid": f"bid_leg{leg_num}",
+        "ask": f"ask_leg{leg_num}",
+        "delta": f"delta_leg{leg_num}",
+    }
+    if "underlying_price" in options.columns:
+        rename_map["underlying_price"] = price_col
+    return options.rename(columns=rename_map)
 
 
 def _get_calendar_leg_columns(leg_num: int, same_strike: bool) -> List[str]:
@@ -93,8 +93,6 @@ def _get_calendar_leg_columns(leg_num: int, same_strike: bool) -> List[str]:
         f"ask_leg{leg_num}",
         f"delta_leg{leg_num}",
     ]
-    if leg_num == 1:
-        cols.append("underlying_price_entry")
     cols.append(strike_col)
     return cols
 

--- a/optopsy/checks.py
+++ b/optopsy/checks.py
@@ -43,7 +43,6 @@ def _format_validation_error(e: ValidationError) -> str:
 # Required columns and their accepted dtypes for option chain DataFrames.
 expected_types: Dict[str, Tuple[str, ...]] = {
     "underlying_symbol": ("object", "str"),
-    "underlying_price": ("int64", "float64"),
     "option_type": ("object", "str"),
     "expiration": ("datetime64[ns]", "datetime64[us]"),
     "quote_date": ("datetime64[ns]", "datetime64[us]"),

--- a/optopsy/definitions.py
+++ b/optopsy/definitions.py
@@ -23,8 +23,6 @@ evaluated_cols: List[str] = [
     "quote_date_exit",
     "dte_entry",
     "strike",
-    "underlying_price_entry",
-    "underlying_price_exit",
     "bid_entry",
     "ask_entry",
     "bid_exit",
@@ -36,7 +34,6 @@ evaluated_cols: List[str] = [
 # columns of dataframe after generating strategy
 single_strike_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry",
     "quote_date_entry",
     "option_type",
     "expiration",
@@ -51,7 +48,6 @@ single_strike_internal_cols: List[str] = [
 
 straddle_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry",
     "expiration",
     "dte_entry",
     "option_type_leg1",
@@ -67,7 +63,6 @@ straddle_internal_cols: List[str] = [
 
 double_strike_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry_leg1",
     "expiration",
     "dte_entry",
     "option_type_leg1",
@@ -83,7 +78,6 @@ double_strike_internal_cols: List[str] = [
 
 triple_strike_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry_leg1",
     "expiration",
     "dte_entry",
     "dte_range",
@@ -103,7 +97,6 @@ triple_strike_internal_cols: List[str] = [
 
 quadruple_strike_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry_leg1",
     "expiration",
     "dte_entry",
     "dte_range",
@@ -148,7 +141,6 @@ quadruple_strike_external_cols: List[str] = [
 # Calendar spread columns (same strike, different expirations)
 calendar_spread_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry",
     "option_type",
     "strike",
     "expiration_leg1",
@@ -173,7 +165,6 @@ calendar_spread_external_cols: List[str] = [
 # Diagonal spread columns (different strikes, different expirations)
 diagonal_spread_internal_cols: List[str] = [
     "underlying_symbol",
-    "underlying_price_entry",
     "option_type",
     "strike_leg1",
     "strike_leg2",

--- a/optopsy/strategies/_helpers.py
+++ b/optopsy/strategies/_helpers.py
@@ -91,7 +91,6 @@ def _straddles(
             "strike",
             "dte_entry",
             "dte_range",
-            "underlying_price_entry",
         ],
         params=kwargs,
     )

--- a/optopsy/ui/tools/_quality_checks.py
+++ b/optopsy/ui/tools/_quality_checks.py
@@ -27,7 +27,6 @@ def _handle_check_data_quality(arguments, dataset, signals, datasets, results, _
     # ---------------------------------------------------------------
     _CORE_REQUIRED_COLS: dict[str, tuple[str, ...]] = {
         "underlying_symbol": ("object", "str"),
-        "underlying_price": ("int64", "float64"),
         "option_type": ("object", "str"),
         "expiration": ("datetime64[ns]", "datetime64[us]"),
         "quote_date": ("datetime64[ns]", "datetime64[us]"),
@@ -57,9 +56,9 @@ def _handle_check_data_quality(arguments, dataset, signals, datasets, results, _
             f"**Required Columns** — dtype mismatches: {'; '.join(dtype_mismatches)}\n"
         )
     else:
-        findings.append("PASS: all 9 required columns present with correct dtypes")
+        findings.append("PASS: all 8 required columns present with correct dtypes")
         display_parts.append(
-            "**Required Columns** — all 9 present with correct dtypes\n"
+            "**Required Columns** — all 8 present with correct dtypes\n"
         )
 
     # ---------------------------------------------------------------
@@ -98,7 +97,6 @@ def _handle_check_data_quality(arguments, dataset, signals, datasets, results, _
     # ---------------------------------------------------------------
     _NULL_CHECK_COLS = [
         "delta",
-        "underlying_price",
         "bid",
         "ask",
         "volume",

--- a/tests/test_tools_check_data_quality.py
+++ b/tests/test_tools_check_data_quality.py
@@ -16,7 +16,7 @@ from optopsy.ui.tools import execute_tool
 
 @pytest.fixture
 def clean_data():
-    """Minimal clean option dataset — all 9 required columns, no issues."""
+    """Minimal clean option dataset — all 8 required columns, no issues."""
     exp = datetime.datetime(2024, 3, 15)
     dates = pd.to_datetime(
         ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-08"]
@@ -70,7 +70,7 @@ class TestCheckDataQualityBasic:
     def test_clean_data_pass(self, clean_data):
         result = execute_tool("check_data_quality", {}, clean_data)
         assert "PASS" in result.llm_summary
-        assert "all 9 required columns" in result.llm_summary
+        assert "all 8 required columns" in result.llm_summary
         assert result.user_display is not None
 
     def test_named_dataset(self, clean_data):
@@ -105,13 +105,6 @@ class TestRequiredColumns:
         assert "ask" in result.llm_summary
         assert "strike" in result.llm_summary
 
-    def test_underlying_price_required(self, clean_data):
-        """underlying_price is a required column (matches engine's expected_types)."""
-        df = clean_data.drop(columns=["underlying_price"])
-        result = execute_tool("check_data_quality", {}, df)
-        assert "FAIL" in result.llm_summary
-        assert "underlying_price" in result.llm_summary
-
 
 # ---------------------------------------------------------------------------
 # Tests — optional columns
@@ -126,7 +119,7 @@ class TestOptionalColumns:
 
     def test_delta_is_required(self, data_with_optionals):
         result = execute_tool("check_data_quality", {}, data_with_optionals)
-        assert "all 9 required columns" in result.llm_summary
+        assert "all 8 required columns" in result.llm_summary
 
     def test_no_optional_columns(self):
         """Dataset with only required columns (no optionals)."""


### PR DESCRIPTION
## Summary

- Remove `underlying_price` from required column validation (`checks.py`), strategy output column definitions (`definitions.py`), straddle join keys, calendar/diagonal spread leg columns, and UI quality checks
- Options data no longer requires stock price to be baked in — the column is accepted when present but not required
- The simulator fallback (`simulator.py`) already handles the missing column defensively, so no changes needed there

## Test plan

- [x] All 1784 tests pass (`uv run pytest tests/ -v`)
- [x] Strategy outputs unchanged (P&L never depended on `underlying_price`)
- [x] Pre-commit hooks (ruff format, ruff check, ty, pytest) all pass
- [ ] Verify `datafeeds.csv_data()` still works with CSVs that include `underlying_price`
- [ ] Verify `datafeeds.csv_data()` works with CSVs that omit `underlying_price`

🤖 Generated with [Claude Code](https://claude.com/claude-code)