### PR TITLE
Add DataFrame entry points and replace apply_signal with signal_dates

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -258,7 +258,7 @@ When `raw=True`, strategies return individual trade details:
 
 Functions for filtering strategy entries/exits using technical analysis or custom conditions. See the [Entry Signals](entry-signals.md) page for full usage examples.
 
-::: optopsy.signals.apply_signal
+::: optopsy.signals.signal_dates
 
 ::: optopsy.signals.custom_signal
 

--- a/docs/entry-signals.md
+++ b/docs/entry-signals.md
@@ -1,22 +1,47 @@
 # Entry Signals
 
-Filter strategy entries using 80+ technical analysis signals powered by [pandas-ta-classic](https://github.com/xgboosted/pandas-ta-classic). Use `apply_signal` to compute valid dates, then pass them as `entry_dates` or `exit_dates` to any strategy.
+Filter strategy entries using 80+ technical analysis signals powered by [pandas-ta-classic](https://github.com/xgboosted/pandas-ta-classic). Use `signal_dates` to compute valid dates from stock price data, then pass them as `entry_dates` or `exit_dates` to any strategy.
 
 ```python
-from optopsy import long_calls, apply_signal, rsi_below, sustained, signal, day_of_week
+import optopsy as op
+
+# Load stock and options data separately
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
 
 # Enter only when RSI(14) is below 30
-entry_dates = apply_signal(data, rsi_below(14, 30))
-results = long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.rsi_below(14, 30))
+results = op.long_calls(options, entry_dates=entry_dates)
 
 # Require RSI below 30 for 5 consecutive days
-entry_dates = apply_signal(data, sustained(rsi_below(14, 30), days=5))
-results = long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.sustained(op.rsi_below(14, 30), days=5))
+results = op.long_calls(options, entry_dates=entry_dates)
 
 # Compose signals with & and |
-sig = signal(rsi_below(14, 30)) & signal(day_of_week(3))  # Oversold + Thursday
-entry_dates = apply_signal(data, sig)
-results = long_calls(data, entry_dates=entry_dates)
+sig = op.signal(op.rsi_below(14, 30)) & op.signal(op.day_of_week(3))  # Oversold + Thursday
+entry_dates = op.signal_dates(stocks, sig)
+results = op.long_calls(options, entry_dates=entry_dates)
+```
+
+## How It Works
+
+Signals are computed on **stock price data** (OHLCV), not options data. The flow is:
+
+1. **Load stock data** — via `load_cached_stocks()` or your own DataFrame
+2. **Build signals** — run signal functions on stock data to get entry/exit dates
+3. **Run strategy** — pass the dates to a strategy along with options data
+
+```python
+# Stock data needs: underlying_symbol, quote_date, close
+# Optional: open, high, low, volume (for OHLCV signals)
+stocks = op.load_cached_stocks("SPY")
+
+# Or bring your own DataFrame
+stocks = pd.DataFrame({
+    "underlying_symbol": "SPY",
+    "quote_date": my_dates,
+    "close": my_prices,
+})
 ```
 
 ## Available Signals
@@ -91,7 +116,7 @@ Require OHLCV data with a `volume` column.
 
 ### IV Rank
 
-Require options data with an `implied_volatility` column.
+Require options data with an `implied_volatility` column. IV rank signals are the exception — they run on options data, not stock data.
 
 | Signal | Description | Default Parameters |
 |--------|-------------|-------------------|
@@ -124,11 +149,13 @@ Require options data with an `implied_volatility` column.
 
 ```python
 import optopsy as op
-from optopsy import apply_signal, rsi_below, rsi_above
 
-entry_dates = apply_signal(data, rsi_below(period=14, threshold=30))
-exit_dates = apply_signal(data, rsi_above(period=14, threshold=70))
-results = op.long_calls(data, entry_dates=entry_dates, exit_dates=exit_dates)
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
+
+entry_dates = op.signal_dates(stocks, op.rsi_below(period=14, threshold=30))
+exit_dates = op.signal_dates(stocks, op.rsi_above(period=14, threshold=70))
+results = op.long_calls(options, entry_dates=entry_dates, exit_dates=exit_dates)
 ```
 
 ### SMA - trend filter
@@ -136,28 +163,22 @@ results = op.long_calls(data, entry_dates=entry_dates, exit_dates=exit_dates)
 Only enter when price is above its 50-day moving average:
 
 ```python
-from optopsy import apply_signal, sma_above
-
-entry_dates = apply_signal(data, sma_above(period=50))
-results = op.short_puts(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.sma_above(period=50))
+results = op.short_puts(options, entry_dates=entry_dates)
 ```
 
 ### MACD - enter on bullish crossover
 
 ```python
-from optopsy import apply_signal, macd_cross_above
-
-entry_dates = apply_signal(data, macd_cross_above(fast=12, slow=26, signal_period=9))
-results = op.long_call_spread(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.macd_cross_above(fast=12, slow=26, signal_period=9))
+results = op.long_call_spread(options, entry_dates=entry_dates)
 ```
 
 ### Stochastic - oversold entry
 
 ```python
-from optopsy import apply_signal, stoch_below
-
-entry_dates = apply_signal(data, stoch_below(k_period=14, d_period=3, threshold=20))
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.stoch_below(k_period=14, d_period=3, threshold=20))
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ### Bollinger Bands - mean reversion
@@ -165,10 +186,8 @@ results = op.long_calls(data, entry_dates=entry_dates)
 Enter when price dips below the lower band:
 
 ```python
-from optopsy import apply_signal, bb_below_lower
-
-entry_dates = apply_signal(data, bb_below_lower(length=20, std=2.0))
-results = op.long_puts(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.bb_below_lower(length=20, std=2.0))
+results = op.long_puts(options, entry_dates=entry_dates)
 ```
 
 ### EMA Crossover - golden cross
@@ -176,10 +195,8 @@ results = op.long_puts(data, entry_dates=entry_dates)
 Fast EMA crosses above slow EMA:
 
 ```python
-from optopsy import apply_signal, ema_cross_above
-
-entry_dates = apply_signal(data, ema_cross_above(fast=10, slow=50))
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.ema_cross_above(fast=10, slow=50))
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ### ADX - trend strength filter
@@ -187,11 +204,9 @@ results = op.long_calls(data, entry_dates=entry_dates)
 Only enter trend-following strategies when ADX confirms a strong trend:
 
 ```python
-from optopsy import apply_signal, adx_above, signal, ema_cross_above
-
-entry = signal(adx_above(period=14, threshold=25)) & signal(ema_cross_above(10, 50))
-entry_dates = apply_signal(data, entry)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry = op.signal(op.adx_above(period=14, threshold=25)) & op.signal(op.ema_cross_above(10, 50))
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ### Supertrend - trend direction
@@ -199,10 +214,8 @@ results = op.long_calls(data, entry_dates=entry_dates)
 Enter when Supertrend flips bullish:
 
 ```python
-from optopsy import apply_signal, supertrend_buy
-
-entry_dates = apply_signal(data, supertrend_buy(period=7, multiplier=3.0))
-results = op.long_call_spread(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.supertrend_buy(period=7, multiplier=3.0))
+results = op.long_call_spread(options, entry_dates=entry_dates)
 ```
 
 ### ATR - low-volatility regime filter
@@ -210,10 +223,8 @@ results = op.long_call_spread(data, entry_dates=entry_dates)
 Only sell premium in low-volatility regimes:
 
 ```python
-from optopsy import apply_signal, atr_below
-
-entry_dates = apply_signal(data, atr_below(period=14, multiplier=0.75))
-results = op.iron_condor(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.atr_below(period=14, multiplier=0.75))
+results = op.iron_condor(options, entry_dates=entry_dates)
 ```
 
 ### Keltner Channel - breakout entry
@@ -221,10 +232,8 @@ results = op.iron_condor(data, entry_dates=entry_dates)
 Enter when price breaks above the upper Keltner Channel:
 
 ```python
-from optopsy import apply_signal, kc_above_upper
-
-entry_dates = apply_signal(data, kc_above_upper(length=20, scalar=1.5))
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.kc_above_upper(length=20, scalar=1.5))
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ### Squeeze - volatility compression
@@ -232,10 +241,8 @@ results = op.long_calls(data, entry_dates=entry_dates)
 Enter when the squeeze releases (Bollinger Bands expand outside Keltner Channels):
 
 ```python
-from optopsy import apply_signal, squeeze_off
-
-entry_dates = apply_signal(data, squeeze_off())
-results = op.long_straddles(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.squeeze_off())
+results = op.long_straddles(options, entry_dates=entry_dates)
 ```
 
 ### Volume - MFI oversold
@@ -243,20 +250,16 @@ results = op.long_straddles(data, entry_dates=entry_dates)
 Enter when Money Flow Index indicates oversold conditions:
 
 ```python
-from optopsy import apply_signal, mfi_below
-
-entry_dates = apply_signal(stock_df, mfi_below(period=14, threshold=20))
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.mfi_below(period=14, threshold=20))
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ### Calendar - restrict entries to specific days
 
 ```python
-from optopsy import apply_signal, day_of_week
-
 # Enter only on Mondays and Fridays
-entry_dates = apply_signal(data, day_of_week(0, 4))
-results = op.short_straddles(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.day_of_week(0, 4))
+results = op.short_straddles(options, entry_dates=entry_dates)
 ```
 
 ## Combining Multiple Signals
@@ -264,24 +267,25 @@ results = op.short_straddles(data, entry_dates=entry_dates)
 Use the `Signal` class with `&` (AND) and `|` (OR) operators, or the functional `and_signals` / `or_signals` helpers:
 
 ```python
-from optopsy import apply_signal, signal, rsi_below, sma_above, atr_below, day_of_week
-from optopsy import and_signals, or_signals
+import optopsy as op
+
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
 
 # Fluent API: oversold + uptrend + low volatility
-entry = signal(rsi_below(14, 30)) & signal(sma_above(50)) & signal(atr_below(14, 0.75))
-entry_dates = apply_signal(data, entry)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry = op.signal(op.rsi_below(14, 30)) & op.signal(op.sma_above(50)) & op.signal(op.atr_below(14, 0.75))
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_calls(options, entry_dates=entry_dates)
 
 # Functional API: same logic
-entry = and_signals(rsi_below(14, 30), sma_above(50), atr_below(14, 0.75))
-entry_dates = apply_signal(data, entry)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry = op.and_signals(op.rsi_below(14, 30), op.sma_above(50), op.atr_below(14, 0.75))
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_calls(options, entry_dates=entry_dates)
 
 # OR: enter when EITHER condition fires
-from optopsy import macd_cross_above, bb_below_lower
-entry = or_signals(macd_cross_above(), bb_below_lower())
-entry_dates = apply_signal(data, entry)
-results = op.long_call_spread(data, entry_dates=entry_dates)
+entry = op.or_signals(op.macd_cross_above(), op.bb_below_lower())
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_call_spread(options, entry_dates=entry_dates)
 ```
 
 ## Sustained Signals
@@ -289,36 +293,35 @@ results = op.long_call_spread(data, entry_dates=entry_dates)
 Require a condition to persist for multiple consecutive days before triggering:
 
 ```python
-from optopsy import apply_signal, sustained, rsi_below, bb_below_lower
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
 
 # RSI must stay below 30 for 5 straight days
-entry_dates = apply_signal(data, sustained(rsi_below(14, 30), days=5))
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.sustained(op.rsi_below(14, 30), days=5))
+results = op.long_calls(options, entry_dates=entry_dates)
 
 # Bollinger Band breach sustained for 3 days
-entry_dates = apply_signal(data, sustained(bb_below_lower(20, 2.0), days=3))
-results = op.long_puts(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(stocks, op.sustained(op.bb_below_lower(20, 2.0), days=3))
+results = op.long_puts(options, entry_dates=entry_dates)
 ```
 
-## Using Stock OHLCV Data
+## Using Your Own Stock Data
 
-By default, signals compute indicators from the option chain's `close` column. For more accurate TA signals (especially those needing high/low/volume data), use `apply_signal` on a separate stock OHLCV DataFrame and pass the result as `entry_dates`:
+You can use any DataFrame with `underlying_symbol`, `quote_date`, and `close` columns. Signals that need high/low/volume will use those columns if present, falling back to `close` if not.
 
 ```python
 import pandas as pd
 import optopsy as op
-from optopsy import apply_signal, adx_above, supertrend_buy, signal
 
-# Load OHLCV stock data (must have: underlying_symbol, quote_date, close;
-# optional: open, high, low, volume)
-stock_df = pd.read_csv("SPX_daily_ohlcv.csv", parse_dates=["quote_date"])
+# Load your own OHLCV data
+stock_df = pd.read_csv("SPY_daily.csv", parse_dates=["quote_date"])
 
-# Compute entry dates from stock data using real high/low for trend signals
-entry = signal(adx_above(period=14, threshold=25)) & signal(supertrend_buy())
-entry_dates = apply_signal(stock_df, entry)
+# Use it directly with signal_dates
+entry = op.signal(op.adx_above(period=14, threshold=25)) & op.signal(op.supertrend_buy())
+entry_dates = op.signal_dates(stock_df, entry)
 
-# Pass pre-computed dates to the strategy
-results = op.long_straddles(data, entry_dates=entry_dates)
+options = op.load_cached_options("SPY")
+results = op.long_straddles(options, entry_dates=entry_dates)
 ```
 
 !!! tip
@@ -326,26 +329,24 @@ results = op.long_straddles(data, entry_dates=entry_dates)
 
 ## IV Rank - volatility regime filter
 
-IV Rank measures where current implied volatility sits relative to its trailing range. Requires an `implied_volatility` column in your options data.
+IV Rank measures where current implied volatility sits relative to its trailing range. Requires an `implied_volatility` column in your options data. This is the one signal type that runs on options data, not stock data.
 
 ### Sell premium when IV is elevated
 
 ```python
-from optopsy import apply_signal, iv_rank_above
+options = op.load_cached_options("SPY")
 
 # Enter short strategies when IV rank is above 50th percentile (1-year lookback)
-entry_dates = apply_signal(data, iv_rank_above(threshold=0.5, window=252))
-results = op.iron_condor(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(options, op.iv_rank_above(threshold=0.5, window=252))
+results = op.iron_condor(options, entry_dates=entry_dates)
 ```
 
 ### Buy options when IV is cheap
 
 ```python
-from optopsy import apply_signal, iv_rank_below
-
 # Enter long strategies when IV rank is in the bottom 30%
-entry_dates = apply_signal(data, iv_rank_below(threshold=0.3, window=252))
-results = op.long_straddles(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(options, op.iv_rank_below(threshold=0.3, window=252))
+results = op.long_straddles(options, entry_dates=entry_dates)
 ```
 
 !!! note
@@ -368,10 +369,11 @@ my_signals = pd.DataFrame({
 
 # Create a signal from the DataFrame
 sig = op.custom_signal(my_signals, flag_col="buy")
-entry_dates = op.apply_signal(my_signals, sig)
+entry_dates = op.signal_dates(my_signals, sig)
 
 # Pass to any strategy
-results = op.long_calls(data, entry_dates=entry_dates, raw=True)
+options = op.load_cached_options("SPY")
+results = op.long_calls(options, entry_dates=entry_dates, raw=True)
 ```
 
 The DataFrame must contain `underlying_symbol`, `quote_date`, and the flag column. Integer (0/1), nullable boolean, and NaN values are all handled — NaN is treated as False.
@@ -385,8 +387,10 @@ sig = op.custom_signal(my_signals, flag_col="buy")
 
 # Combine with built-in signals using & and |
 combined = op.signal(sig) & op.signal(op.day_of_week(1))
-entry_dates = op.apply_signal(my_signals, combined)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry_dates = op.signal_dates(my_signals, combined)
+
+options = op.load_cached_options("SPY")
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ## Custom Signal Functions
@@ -395,17 +399,19 @@ Any function matching the signature `(pd.DataFrame) -> pd.Series[bool]` can be u
 
 ```python
 import optopsy as op
-from optopsy import apply_signal, signal, rsi_below
 
-# Custom: only enter when close price is above 4000
-def price_above_4000(data):
-    return data["close"] > 4000
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
 
-entry_dates = apply_signal(data, price_above_4000)
-results = op.iron_condor(data, entry_dates=entry_dates)
+# Custom: only enter when close price is above 400
+def price_above_400(data):
+    return data["close"] > 400
+
+entry_dates = op.signal_dates(stocks, price_above_400)
+results = op.iron_condor(options, entry_dates=entry_dates)
 
 # Combine custom signals with built-in ones
-entry = signal(price_above_4000) & signal(rsi_below(14, 30))
-entry_dates = apply_signal(data, entry)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry = op.signal(price_above_400) & op.signal(op.rsi_below(14, 30))
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_calls(options, entry_dates=entry_dates)
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -62,7 +62,7 @@ Backtest long straddles on specific dates using `entry_dates`:
 
 ```python
 import pandas as pd
-from optopsy import custom_signal, apply_signal
+import optopsy as op
 
 # Define earnings dates as entry signals
 earnings_dates = pd.DataFrame({
@@ -71,10 +71,11 @@ earnings_dates = pd.DataFrame({
     "enter": [True] * 4,
 })
 
-sig = custom_signal(earnings_dates, flag_col="enter")
-entry_dates = apply_signal(earnings_dates, sig)
+sig = op.custom_signal(earnings_dates, flag_col="enter")
+entry_dates = op.signal_dates(earnings_dates, sig)
 
 # Backtest ATM straddles — only enters on earnings dates
+data = op.csv_data('SPX_2023.csv')
 results = op.long_straddles(
     data,
     max_entry_dte=7,  # Enter up to 1 week before expiration
@@ -435,10 +436,10 @@ my_flags = pd.DataFrame({
 })
 
 sig = op.custom_signal(my_flags, flag_col="go")
-entry_dates = op.apply_signal(my_flags, sig)
+entry_dates = op.signal_dates(my_flags, sig)
 
-data = op.csv_data('SPY_2023.csv')
-results = op.long_calls(data, entry_dates=entry_dates)
+options = op.csv_data('SPY_2023.csv')
+results = op.long_calls(options, entry_dates=entry_dates)
 print(results)
 ```
 
@@ -558,12 +559,15 @@ results = op.iron_condor(
 Optopsy supports filtering entries with technical analysis indicators. See the [Entry Signals](entry-signals.md) page for the full reference. Here's a quick example:
 
 ```python
-from optopsy import apply_signal, rsi_below, sma_above, signal
+import optopsy as op
+
+stocks = op.load_cached_stocks("SPY")
+options = op.load_cached_options("SPY")
 
 # Enter long calls only when RSI < 30 AND price is above the 50-day SMA
-entry = signal(rsi_below(14, 30)) & signal(sma_above(50))
-entry_dates = apply_signal(data, entry)
-results = op.long_calls(data, entry_dates=entry_dates)
+entry = op.signal(op.rsi_below(14, 30)) & op.signal(op.sma_above(50))
+entry_dates = op.signal_dates(stocks, entry)
+results = op.long_calls(options, entry_dates=entry_dates)
 ```
 
 ## Data Sources

--- a/optopsy/__init__.py
+++ b/optopsy/__init__.py
@@ -20,7 +20,7 @@ For detailed documentation, visit: https://github.com/michaelchu/optopsy
 
 __version__ = "2.2.0"
 
-from .datafeeds import csv_data
+from .datafeeds import csv_data, load_cached_options, load_cached_stocks, options_data
 from .metrics import (
     calmar_ratio,
     compute_risk_metrics,
@@ -46,7 +46,6 @@ from .signals import (
     and_signals,
     ao_above,
     ao_below,
-    apply_signal,
     aroon_cross_above,
     aroon_cross_below,
     atr_above,
@@ -101,6 +100,7 @@ from .signals import (
     rsi_above,
     rsi_below,
     signal,
+    signal_dates,
     sma_above,
     sma_below,
     smi_cross_above,
@@ -241,6 +241,9 @@ __all__ = [
     "long_put_diagonal",
     "short_put_diagonal",
     "csv_data",
+    "options_data",
+    "load_cached_options",
+    "load_cached_stocks",
     # Type definitions
     "Commission",
     "StrategyParams",
@@ -249,7 +252,7 @@ __all__ = [
     "CalendarStrategyParamsDict",
     "TargetRange",
     # Signal functions — combinators & utilities
-    "apply_signal",
+    "signal_dates",
     "and_signals",
     "or_signals",
     "sustained",

--- a/optopsy/datafeeds.py
+++ b/optopsy/datafeeds.py
@@ -1,9 +1,11 @@
-"""CSV data import and column normalization for option chain data.
+"""Data import and column normalization for option chain data.
 
-The primary entry point is ``csv_data()``, which reads a CSV file and maps
-its columns to the standardized names used throughout optopsy (e.g.
-``underlying_symbol``, ``quote_date``, ``strike``).  Column positions are
-specified by integer index, allowing the library to work with any CSV layout.
+Entry points:
+
+- ``csv_data()`` — reads a CSV file and maps columns by integer index.
+- ``options_data()`` — validates/normalizes an already-loaded DataFrame.
+- ``load_cached_options()`` — reads from the parquet cache produced by
+  ``optopsy-data download`` and returns a normalized DataFrame.
 
 The module also handles:
 - Date column inference (``_infer_date_cols``)
@@ -200,3 +202,182 @@ def csv_data(
         raise ValueError(f"Column mapping error in {file_path}: {str(e)}")
     except Exception as e:
         raise ValueError(f"Unexpected error reading CSV file {file_path}: {str(e)}")
+
+
+_REQUIRED_COLUMNS = [
+    "underlying_symbol",
+    "option_type",
+    "expiration",
+    "quote_date",
+    "strike",
+    "bid",
+    "ask",
+    "delta",
+]
+
+
+def options_data(
+    df: pd.DataFrame,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> pd.DataFrame:
+    """Validate and normalize an existing DataFrame for use with strategies.
+
+    Accepts a DataFrame that already has named columns matching the standard
+    optopsy schema.  Unlike ``csv_data()`` which maps columns by integer index,
+    this function expects columns to already be named correctly.
+
+    Args:
+        df: DataFrame with named columns (at minimum the 8 required columns:
+            underlying_symbol, option_type, expiration, quote_date, strike,
+            bid, ask, delta).  Extra columns (greeks, volume, etc.) are
+            passed through unchanged.
+        start_date: Optional start date for filtering (inclusive).
+        end_date: Optional end date for filtering (inclusive).
+
+    Returns:
+        Normalized DataFrame with date columns converted to datetime64 and
+        optional date filtering applied.
+
+    Raises:
+        ValueError: If any required column is missing from the DataFrame.
+    """
+    missing = [col for col in _REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    return df.pipe(_infer_date_cols).pipe(_trim_dates, start_date, end_date)
+
+
+def load_cached_options(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> pd.DataFrame:
+    """Load cached options data downloaded by ``optopsy-data download``.
+
+    Reads from the parquet cache and normalizes the DataFrame for use with
+    strategy functions.  Requires the ``optopsy[data]`` extra (pyarrow).
+
+    Args:
+        symbol: Ticker symbol (e.g. ``"SPY"``).
+        start_date: Optional start date for filtering (inclusive).
+        end_date: Optional end date for filtering (inclusive).
+
+    Returns:
+        Normalized DataFrame ready for strategy functions.
+
+    Raises:
+        FileNotFoundError: If no cached data exists for *symbol*.
+        ImportError: If pyarrow is not installed.
+    """
+    try:
+        from .data.providers.cache import ParquetCache
+    except ImportError as exc:
+        raise ImportError(
+            "pyarrow is required for load_cached_options. "
+            "Install it with: pip install optopsy[data]"
+        ) from exc
+
+    cache = ParquetCache()
+    df = cache.read("options", symbol)
+    if df is None or df.empty:
+        raise FileNotFoundError(
+            f"No cached options data for '{symbol}'. "
+            f"Download it first with: optopsy-data download {symbol}"
+        )
+
+    # Select columns matching _select_options_columns from EODHDProvider
+    keep = [
+        "underlying_symbol",
+        "option_type",
+        "expiration",
+        "quote_date",
+        "strike",
+        "bid",
+        "ask",
+    ]
+    optional = [
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+        "implied_volatility",
+        "volume",
+        "open_interest",
+    ]
+    keep.extend([c for c in optional if c in df.columns])
+    df = df[[c for c in keep if c in df.columns]]
+
+    # Normalize option_type to lowercase single char (c/p)
+    if "option_type" in df.columns:
+        df = df.copy()
+        df["option_type"] = (
+            df["option_type"]
+            .astype(str)
+            .str.strip()
+            .str.lower()
+            .map({"call": "c", "put": "p", "c": "c", "p": "p"})
+        )
+
+    return options_data(df, start_date=start_date, end_date=end_date)
+
+
+def load_cached_stocks(
+    symbol: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> pd.DataFrame:
+    """Load cached stock OHLCV data downloaded by ``optopsy-data download -s``.
+
+    Reads from the yfinance parquet cache and returns a DataFrame suitable for
+    use with ``signal_dates()`` and the signals system.
+    Requires the ``optopsy[data]`` extra (pyarrow).
+
+    Args:
+        symbol: Ticker symbol (e.g. ``"SPY"``).
+        start_date: Optional start date for filtering (inclusive).
+        end_date: Optional end date for filtering (inclusive).
+
+    Returns:
+        DataFrame with columns ``underlying_symbol``, ``quote_date``,
+        ``open``, ``high``, ``low``, ``close``, ``volume`` (where available).
+
+    Raises:
+        FileNotFoundError: If no cached stock data exists for *symbol*.
+        ImportError: If pyarrow is not installed.
+    """
+    try:
+        from .data.providers.cache import ParquetCache
+    except ImportError as exc:
+        raise ImportError(
+            "pyarrow is required for load_cached_stocks. "
+            "Install it with: pip install optopsy[data]"
+        ) from exc
+
+    cache = ParquetCache()
+    df = cache.read("yf_stocks", symbol)
+    if df is None or df.empty:
+        raise FileNotFoundError(
+            f"No cached stock data for '{symbol}'. "
+            f"Download it first with: optopsy-data download {symbol} -s"
+        )
+
+    df = df.copy()
+
+    # Rename 'date' → 'quote_date' for compatibility with signal_dates
+    if "quote_date" not in df.columns and "date" in df.columns:
+        df = df.rename(columns={"date": "quote_date"})
+
+    # Ensure quote_date is datetime
+    if "quote_date" in df.columns:
+        df["quote_date"] = pd.to_datetime(df["quote_date"])
+
+    # Apply date filtering on quote_date
+    if start_date is not None:
+        df = df[df["quote_date"] >= pd.to_datetime(start_date)]
+    if end_date is not None:
+        df = df[df["quote_date"] <= pd.to_datetime(end_date)]
+
+    return df

--- a/optopsy/filters.py
+++ b/optopsy/filters.py
@@ -59,13 +59,13 @@ def _apply_signal_filter(
     Filter data to only include rows matching valid (symbol, date) pairs.
 
     Both the option chain data (normalized at the root of _process_strategy /
-    _process_calendar_strategy) and signal dates (normalized in apply_signal)
+    _process_calendar_strategy) and signal dates (normalized in signal_dates)
     are already date-only, so this is a straightforward inner join.
 
     Args:
         data: DataFrame to filter (already date-normalized)
         valid_dates: DataFrame with (underlying_symbol, quote_date) of valid dates
-            (already date-normalized via apply_signal)
+            (already date-normalized via signal_dates)
         date_col: Name of the date column in data to match against (default: quote_date)
 
     Returns:

--- a/optopsy/signals/__init__.py
+++ b/optopsy/signals/__init__.py
@@ -7,36 +7,36 @@ Series indicating which dates are valid for entry/exit.
 Built-in signals can be combined with and_signals() / or_signals(), or with
 the fluent Signal class using & and | operators.
 
-Use ``apply_signal()`` to run a signal function on data and get back a
+Use ``signal_dates()`` to run a signal function on stock data and get back a
 DataFrame of valid ``(underlying_symbol, quote_date)`` pairs to pass as
 ``entry_dates`` or ``exit_dates`` to any strategy.
 
 Example:
-    >>> from optopsy.signals import rsi_below, day_of_week, and_signals, apply_signal
+    >>> from optopsy.signals import rsi_below, day_of_week, and_signals, signal_dates
     >>> import optopsy as op
     >>> data = op.csv_data('./SPX_2018.csv')
     >>> stock = load_stock_data(...)  # OHLCV DataFrame
 
     >>> # Compute entry dates: Thursdays when RSI(14) < 30
     >>> sig = and_signals(rsi_below(14, 30), day_of_week(3))
-    >>> entry_dates = apply_signal(stock, sig)
+    >>> entry_dates = signal_dates(stock, sig)
     >>> results = op.long_calls(data, entry_dates=entry_dates, raw=True)
 
     >>> # Fluent API with Signal class
     >>> sig = signal(rsi_below(14, 30)) & signal(day_of_week(3))
-    >>> entry_dates = apply_signal(stock, sig)
+    >>> entry_dates = signal_dates(stock, sig)
     >>> results = op.long_calls(data, entry_dates=entry_dates, raw=True)
 """
 
 # Type alias
-# Combinators, Signal class, apply_signal, custom_signal
+# Combinators, Signal class, signal_dates, custom_signal
 from ._combinators import (
     Signal,
     and_signals,
-    apply_signal,
     custom_signal,
     or_signals,
     signal,
+    signal_dates,
     sustained,
 )
 
@@ -223,7 +223,7 @@ __all__ = [
     "custom_signal",
     "Signal",
     "signal",
-    "apply_signal",
+    "signal_dates",
     # Momentum
     "rsi_below",
     "rsi_above",

--- a/optopsy/signals/_combinators.py
+++ b/optopsy/signals/_combinators.py
@@ -1,4 +1,4 @@
-"""Signal combinators, the Signal class, apply_signal, and custom_signal."""
+"""Signal combinators, the Signal class, signal_dates, and custom_signal."""
 
 import pandas as pd
 
@@ -139,52 +139,50 @@ def signal(func: SignalFunc) -> Signal:
     return Signal(func)
 
 
-# ---------------------------------------------------------------------------
-# apply_signal — public helper to compute valid dates from a signal
-# ---------------------------------------------------------------------------
-
-
-def apply_signal(
-    data: pd.DataFrame,
+def signal_dates(
+    stock_data: pd.DataFrame,
     signal_func: SignalFunc,
-    stock_data: "pd.DataFrame | None" = None,
 ) -> pd.DataFrame:
-    """Run a signal function on data and return valid (symbol, date) pairs.
+    """Run a signal on stock data and return valid (symbol, date) pairs.
+
+    This is the recommended way to generate ``entry_dates`` / ``exit_dates``
+    for strategy functions.  Signals are computed entirely from stock price
+    data — no options data is involved.
 
     Args:
-        data: DataFrame with at least ``underlying_symbol`` and ``quote_date``.
-        signal_func: Callable that takes a DataFrame and returns a boolean Series.
-        stock_data: Optional OHLCV DataFrame with stock prices.  When provided
-            and *data* lacks a ``close`` column, the stock prices are merged in
-            by ``(underlying_symbol, quote_date)``.  This is useful for IV rank
-            signals that need a price column for ATM strike selection while the
-            options data itself has no stock price.  Accepts yfinance output
-            directly (DatetimeIndex, ``Close`` column, etc.).
+        stock_data: OHLCV DataFrame with at least ``underlying_symbol``,
+            ``quote_date``, and ``close``.  Extra columns (``high``, ``low``,
+            ``volume``) are used by signals that need them.  Accepts output
+            from ``load_cached_stocks()`` directly.
+        signal_func: A signal function (e.g. ``op.rsi_below()``) or a
+            composed signal using ``&`` / ``|`` operators on ``Signal``
+            objects.
 
     Returns:
         DataFrame with columns ``(underlying_symbol, quote_date)`` for
-        dates where the signal is True.
-    """
-    df = data.copy()
-    df["quote_date"] = normalize_dates(df["quote_date"])
-    if "close" not in df.columns and stock_data is not None:
-        from ..strategies._helpers import _normalize_stock_data
+        dates where the signal is True.  Pass this directly to a strategy
+        via ``entry_dates`` or ``exit_dates``.
 
-        stock = _normalize_stock_data(stock_data, df)
-        df = df.merge(
-            stock[["underlying_symbol", "quote_date", "close"]],
-            on=["underlying_symbol", "quote_date"],
-            how="left",
+    Example::
+
+        stocks = op.load_cached_stocks("SPY")
+        entry = op.signal_dates(stocks, op.rsi_below(threshold=30))
+        results = op.long_calls(options, entry_dates=entry)
+
+    Example with composed signals::
+
+        entry = op.signal_dates(
+            stocks,
+            op.signal(op.rsi_below()) & op.signal(op.sma_above(200)),
         )
-    requires_per_strike = getattr(signal_func, "requires_per_strike", False)
-    if requires_per_strike:
-        df = df.sort_values(["underlying_symbol", "quote_date"]).reset_index(drop=True)
-    else:
-        df = (
-            df.drop_duplicates(["underlying_symbol", "quote_date"])
-            .sort_values(["underlying_symbol", "quote_date"])
-            .reset_index(drop=True)
-        )
+    """
+    df = stock_data.copy()
+    df["quote_date"] = normalize_dates(df["quote_date"])
+    df = (
+        df.drop_duplicates(["underlying_symbol", "quote_date"])
+        .sort_values(["underlying_symbol", "quote_date"])
+        .reset_index(drop=True)
+    )
     mask = signal_func(df)
     return (
         df.loc[mask, ["underlying_symbol", "quote_date"]]

--- a/optopsy/signals/iv.py
+++ b/optopsy/signals/iv.py
@@ -20,7 +20,7 @@ def _compute_atm_iv(options_data: pd.DataFrame) -> pd.DataFrame:
     is absent.
 
     Callers should ensure ``resolve_price_column()`` or
-    ``apply_signal()`` has been applied before invoking this function
+    ``signal_dates()`` has been applied before invoking this function
     so that ``close`` is available.
     """
     if "close" not in options_data.columns:

--- a/optopsy/types.py
+++ b/optopsy/types.py
@@ -79,7 +79,7 @@ class StrategyParamsDict(TypedDict, total=False):
 
     # Pre-computed signal dates (optional).
     # DataFrames with (underlying_symbol, quote_date) pairs indicating
-    # valid dates for entry/exit.  Use signals.apply_signal() to generate.
+    # valid dates for entry/exit.  Use signals.signal_dates() to generate.
     entry_dates: Optional[pd.DataFrame]
     exit_dates: Optional[pd.DataFrame]
 

--- a/optopsy/ui/agent.py
+++ b/optopsy/ui/agent.py
@@ -229,7 +229,7 @@ TA indicators, custom logic, model predictions, or even manual date lists.
 
 ### How it works (architecture)
 1. A **signal function** (e.g. `rsi_below(14, 30)`) evaluates a condition on OHLCV price data
-2. `apply_signal(data, signal_func)` runs the signal and returns a DataFrame of valid \
+2. `signal_dates(stock_data, signal_func)` runs the signal and returns a DataFrame of valid \
 `(underlying_symbol, quote_date)` pairs
 3. The strategy receives these as **`entry_dates`** or **`exit_dates`** — pre-computed date \
 filters that restrict which dates are eligible for trade entry/exit
@@ -239,12 +239,12 @@ tool computes the dates behind the scenes. But when users ask how to use the lib
 programmatically, explain the decoupled pattern:
 
 ```python
-from optopsy.signals import rsi_below, apply_signal
+from optopsy.signals import rsi_below, signal_dates
 import optopsy as op
 
 data = op.csv_data('./SPX_2018.csv')
 stock = load_ohlcv_data(...)  # OHLCV DataFrame for the underlying
-entry_dates = apply_signal(stock, rsi_below(14, 30))
+entry_dates = signal_dates(stock, rsi_below(14, 30))
 results = op.long_calls(data, entry_dates=entry_dates, raw=True)
 ```
 

--- a/optopsy/ui/tools/_helpers.py
+++ b/optopsy/ui/tools/_helpers.py
@@ -30,7 +30,7 @@ from optopsy.data._yf_helpers import (  # noqa: F401
 )
 from optopsy.metrics import profit_factor as _profit_factor
 from optopsy.metrics import win_rate as _win_rate
-from optopsy.signals import apply_signal
+from optopsy.signals import signal_dates
 from optopsy.timestamps import normalize_dates
 
 from .._dataframe_utils import stringify_interval_cols
@@ -149,7 +149,7 @@ def _empty_signal_suggestion(
 ) -> str:
     """Build a human-readable suggestion when a signal produces no overlapping dates.
 
-    raw_signal_dates: result of apply_signal() before intersection — the full set
+    raw_signal_dates: result of signal_dates() before intersection — the full set
     of dates where the signal fired in the available price history.
     opt_min / opt_max: the date range of the loaded options dataset.
 
@@ -921,7 +921,7 @@ def _resolve_inline_signal(
     if days > 1:
         sig = _signals.sustained(sig, days)
 
-    raw_dates = apply_signal(signal_data, sig)
+    raw_dates = signal_dates(signal_data, sig)
     filtered = _intersect_with_options_dates(raw_dates, dataset)
     if filtered.empty:
         opt_min = dataset["quote_date"].min().date()

--- a/optopsy/ui/tools/_signals_builder.py
+++ b/optopsy/ui/tools/_signals_builder.py
@@ -7,7 +7,7 @@ from typing import Any
 import pandas as pd
 
 import optopsy.signals as _signals
-from optopsy.signals import apply_signal
+from optopsy.signals import signal_dates
 
 from ._executor import _register, _require_dataset
 from ._helpers import (
@@ -159,7 +159,7 @@ def _handle_build_signal(arguments, dataset, signals, datasets, results, _result
         combined = _signals.and_signals(*built_signals)
 
     # Compute valid dates, intersected with actual options dates.
-    raw_signal_dates = apply_signal(signal_data, combined)
+    raw_signal_dates = signal_dates(signal_data, combined)
     valid_dates = _intersect_with_options_dates(raw_signal_dates, dataset)
 
     # Store in signals dict

--- a/samples/signal_composition.py
+++ b/samples/signal_composition.py
@@ -1,16 +1,15 @@
 """Signal composition example — filtering entries with technical signals.
 
 Demonstrates:
+- Loading stock and options data separately
+- Building signals on stock data with signal_dates()
 - Combining signals with and_signals / or_signals
 - Using sustained() for multi-day confirmation
-- apply_signal() to produce entry_dates for a strategy
-- IV rank signal for premium-selling regimes
+- IV rank signal for premium-selling regimes (runs on options data)
 - custom_signal() from a user-created DataFrame
 
-Note: Many signals (RSI, Bollinger, etc.) require OHLCV stock price data.
-      When option chain data lacks a 'close' column, pass stock_data= to
-      apply_signal().  This example uses the option chain's underlying_last
-      column mapped via csv_data(underlying_price=1) as a proxy.
+Note: Most signals (RSI, Bollinger, etc.) require stock OHLCV price data.
+      IV rank is the exception — it runs on options data with implied_volatility.
 """
 
 import os
@@ -23,7 +22,7 @@ DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "sample_spx_data.csv
 
 
 def load_data():
-    """Load data with implied_volatility for IV rank signals."""
+    """Load options data with implied_volatility for IV rank signals."""
     return op.csv_data(
         DATA_PATH,
         underlying_symbol=0,
@@ -42,11 +41,22 @@ def load_data():
 def main():
     data = load_data()
 
+    # For stock-based signals, we need a price DataFrame with close column.
+    # Here we derive it from the options data as a proxy (in practice, use
+    # op.load_cached_stocks() or your own OHLCV DataFrame).
+    stock_data = (
+        data[["underlying_symbol", "quote_date", "underlying_price"]]
+        .drop_duplicates(["underlying_symbol", "quote_date"])
+        .rename(columns={"underlying_price": "close"})
+        .sort_values(["underlying_symbol", "quote_date"])
+        .reset_index(drop=True)
+    )
+
     # --- 1. Single signal: only enter on Thursdays ---
     print("=" * 60)
     print("ENTRY SIGNAL — Thursdays Only")
     print("=" * 60)
-    thursday_dates = op.apply_signal(data, op.day_of_week(3))
+    thursday_dates = op.signal_dates(stock_data, op.day_of_week(3))
     print(f"Entry dates found: {len(thursday_dates)}")
 
     results = op.long_puts(
@@ -68,7 +78,7 @@ def main():
         op.rsi_below(period=14, threshold=30),
         op.bb_below_lower(length=20, std=2.0),
     )
-    entry_dates = op.apply_signal(data, combined)
+    entry_dates = op.signal_dates(stock_data, combined)
     print(f"Entry dates matching both conditions: {len(entry_dates)}")
 
     if len(entry_dates) > 0:
@@ -87,15 +97,16 @@ def main():
     print("SUSTAINED SIGNAL — RSI Overbought for 3 Days")
     print("=" * 60)
     overbought_3d = op.sustained(op.rsi_above(period=14, threshold=70), days=3)
-    entry_dates = op.apply_signal(data, overbought_3d)
+    entry_dates = op.signal_dates(stock_data, overbought_3d)
     print(f"Sustained overbought dates: {len(entry_dates)}")
 
     # --- 4. IV rank signal: sell premium when IV is high ---
+    # Note: IV rank runs on options data (needs implied_volatility column)
     print("\n" + "=" * 60)
     print("IV RANK SIGNAL — Sell Premium in High IV")
     print("=" * 60)
     high_iv = op.iv_rank_above(threshold=0.5, window=252)
-    iv_dates = op.apply_signal(data, high_iv)
+    iv_dates = op.signal_dates(data, high_iv)
     print(f"High IV rank dates: {len(iv_dates)}")
 
     if len(iv_dates) > 0:
@@ -121,7 +132,7 @@ def main():
             "signal": [True, True, True],
         }
     )
-    custom_dates = op.apply_signal(data, op.custom_signal(custom_df))
+    custom_dates = op.signal_dates(custom_df, op.custom_signal(custom_df))
     print(f"Custom entry dates: {len(custom_dates)}")
 
     results = op.long_calls(

--- a/tests/test_datafeeds.py
+++ b/tests/test_datafeeds.py
@@ -1,11 +1,18 @@
 import os
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 
 import optopsy as op
-from optopsy.datafeeds import _standardize_cols, _trim_cols
+from optopsy.datafeeds import (
+    _standardize_cols,
+    _trim_cols,
+    load_cached_options,
+    load_cached_stocks,
+    options_data,
+)
 
 _TEST_DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "test_data")
 
@@ -361,3 +368,293 @@ class TestStandardizeCols:
         assert "symbol" in result.columns
         assert "price" in result.columns
         assert "delta" not in result.columns
+
+
+# =============================================================================
+# options_data() Tests
+# =============================================================================
+
+
+def _make_options_df(**overrides):
+    """Build a minimal valid options DataFrame for testing."""
+    data = {
+        "underlying_symbol": ["SPX"],
+        "option_type": ["c"],
+        "expiration": ["2020-01-17"],
+        "quote_date": ["2020-01-02"],
+        "strike": [3200.0],
+        "bid": [50.0],
+        "ask": [51.0],
+        "delta": [0.45],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+class TestOptionsData:
+    def test_valid_dataframe(self):
+        """Valid DataFrame with all required columns returns normalized output."""
+        df = _make_options_df()
+        result = options_data(df)
+        assert not result.empty
+        assert pd.api.types.is_datetime64_any_dtype(result["expiration"])
+        assert pd.api.types.is_datetime64_any_dtype(result["quote_date"])
+
+    def test_missing_required_column(self):
+        """Missing required column raises ValueError."""
+        df = _make_options_df()
+        df = df.drop(columns=["delta"])
+        with pytest.raises(ValueError, match="Missing required columns.*delta"):
+            options_data(df)
+
+    def test_multiple_missing_columns(self):
+        """Multiple missing columns are all reported."""
+        df = _make_options_df()
+        df = df.drop(columns=["delta", "bid"])
+        with pytest.raises(ValueError, match="bid.*delta|delta.*bid"):
+            options_data(df)
+
+    def test_extra_columns_preserved(self):
+        """Extra columns (greeks, volume, etc.) pass through unchanged."""
+        df = _make_options_df(gamma=[0.02], theta=[-0.05], volume=[1000])
+        result = options_data(df)
+        assert "gamma" in result.columns
+        assert "theta" in result.columns
+        assert "volume" in result.columns
+        assert result.iloc[0]["gamma"] == 0.02
+
+    def test_date_filtering(self):
+        """Date range filtering works correctly."""
+        df = pd.DataFrame(
+            {
+                "underlying_symbol": ["SPX", "SPX", "SPX"],
+                "option_type": ["c", "c", "c"],
+                "expiration": ["2020-01-17", "2020-06-19", "2021-01-15"],
+                "quote_date": ["2020-01-02", "2020-01-02", "2020-01-02"],
+                "strike": [3200.0, 3200.0, 3200.0],
+                "bid": [50.0, 50.0, 50.0],
+                "ask": [51.0, 51.0, 51.0],
+                "delta": [0.45, 0.45, 0.45],
+            }
+        )
+        result = options_data(
+            df,
+            start_date=datetime(2020, 3, 1),
+            end_date=datetime(2020, 12, 31),
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["expiration"] == pd.Timestamp("2020-06-19")
+
+    def test_string_dates_converted(self):
+        """String date columns are converted to datetime64."""
+        df = _make_options_df()
+        assert not pd.api.types.is_datetime64_any_dtype(df["expiration"])
+        result = options_data(df)
+        assert pd.api.types.is_datetime64_any_dtype(result["expiration"])
+        assert pd.api.types.is_datetime64_any_dtype(result["quote_date"])
+
+    def test_accessible_from_public_api(self):
+        """options_data is accessible via op.options_data."""
+        assert hasattr(op, "options_data")
+        assert op.options_data is options_data
+
+
+# =============================================================================
+# load_cached_options() Tests
+# =============================================================================
+
+
+class TestLoadCachedOptions:
+    def _make_cached_df(self):
+        """Sample DataFrame mimicking parquet cache content."""
+        return pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY", "SPY"],
+                "option_type": ["Call", "Put"],
+                "expiration": pd.to_datetime(["2020-01-17", "2020-01-17"]),
+                "quote_date": pd.to_datetime(["2020-01-02", "2020-01-02"]),
+                "strike": [320.0, 310.0],
+                "bid": [5.0, 4.0],
+                "ask": [5.5, 4.5],
+                "delta": [0.55, -0.40],
+                "gamma": [0.03, 0.03],
+                "theta": [-0.05, -0.04],
+                "vega": [0.15, 0.14],
+                "implied_volatility": [0.20, 0.22],
+                "volume": [1000, 800],
+                # Extra columns that should be excluded
+                "expiration_type": ["monthly", "monthly"],
+                "moneyness": ["ITM", "OTM"],
+                "theoretical": [5.2, 4.3],
+                "dte": [15, 15],
+            }
+        )
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_loads_and_normalizes(self, MockCache):
+        """Loading cached data returns normalized DataFrame."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = self._make_cached_df()
+        MockCache.return_value = mock_instance
+
+        result = load_cached_options("SPY")
+
+        mock_instance.read.assert_called_once_with("options", "SPY")
+        assert not result.empty
+        assert len(result) == 2
+        # option_type normalized to single char
+        assert list(result["option_type"]) == ["c", "p"]
+        # Extra cache columns excluded
+        assert "expiration_type" not in result.columns
+        assert "moneyness" not in result.columns
+        assert "theoretical" not in result.columns
+        assert "dte" not in result.columns
+        # Greeks preserved
+        assert "delta" in result.columns
+        assert "gamma" in result.columns
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_symbol_not_cached(self, MockCache):
+        """Missing symbol raises FileNotFoundError."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = None
+        MockCache.return_value = mock_instance
+
+        with pytest.raises(
+            FileNotFoundError, match="No cached options data for 'AAPL'"
+        ):
+            load_cached_options("AAPL")
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_date_filtering(self, MockCache):
+        """Date range filtering is applied correctly."""
+        cached = pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY", "SPY", "SPY"],
+                "option_type": ["c", "c", "c"],
+                "expiration": pd.to_datetime(
+                    ["2020-01-17", "2020-06-19", "2021-01-15"]
+                ),
+                "quote_date": pd.to_datetime(
+                    ["2020-01-02", "2020-01-02", "2020-01-02"]
+                ),
+                "strike": [320.0, 320.0, 320.0],
+                "bid": [5.0, 5.0, 5.0],
+                "ask": [5.5, 5.5, 5.5],
+                "delta": [0.55, 0.55, 0.55],
+            }
+        )
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = cached
+        MockCache.return_value = mock_instance
+
+        result = load_cached_options(
+            "SPY",
+            start_date=datetime(2020, 3, 1),
+            end_date=datetime(2020, 12, 31),
+        )
+        assert len(result) == 1
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_empty_cache_raises(self, MockCache):
+        """Empty cached DataFrame raises FileNotFoundError."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = pd.DataFrame()
+        MockCache.return_value = mock_instance
+
+        with pytest.raises(FileNotFoundError, match="No cached options data"):
+            load_cached_options("SPY")
+
+    def test_accessible_from_public_api(self):
+        """load_cached_options is accessible via op.load_cached_options."""
+        assert hasattr(op, "load_cached_options")
+        assert op.load_cached_options is load_cached_options
+
+
+# =============================================================================
+# load_cached_stocks() Tests
+# =============================================================================
+
+
+class TestLoadCachedStocks:
+    def _make_cached_stock_df(self):
+        """Sample DataFrame mimicking yfinance parquet cache content."""
+        return pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY", "SPY", "SPY"],
+                "date": pd.to_datetime(["2020-01-02", "2020-01-03", "2020-01-06"]),
+                "open": [320.0, 321.0, 319.0],
+                "high": [322.0, 323.0, 321.0],
+                "low": [319.0, 320.0, 318.0],
+                "close": [321.0, 322.0, 320.0],
+                "volume": [50000000, 48000000, 52000000],
+            }
+        )
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_loads_and_renames_date(self, MockCache):
+        """Loading cached stock data renames 'date' to 'quote_date'."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = self._make_cached_stock_df()
+        MockCache.return_value = mock_instance
+
+        result = load_cached_stocks("SPY")
+
+        mock_instance.read.assert_called_once_with("yf_stocks", "SPY")
+        assert not result.empty
+        assert len(result) == 3
+        assert "quote_date" in result.columns
+        assert "date" not in result.columns
+        assert "close" in result.columns
+        assert "high" in result.columns
+        assert "volume" in result.columns
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_symbol_not_cached(self, MockCache):
+        """Missing symbol raises FileNotFoundError."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = None
+        MockCache.return_value = mock_instance
+
+        with pytest.raises(FileNotFoundError, match="No cached stock data for 'AAPL'"):
+            load_cached_stocks("AAPL")
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_date_filtering(self, MockCache):
+        """Date range filtering works on quote_date."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = self._make_cached_stock_df()
+        MockCache.return_value = mock_instance
+
+        result = load_cached_stocks(
+            "SPY",
+            start_date=datetime(2020, 1, 3),
+            end_date=datetime(2020, 1, 3),
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["close"] == 322.0
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_empty_cache_raises(self, MockCache):
+        """Empty cached DataFrame raises FileNotFoundError."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = pd.DataFrame()
+        MockCache.return_value = mock_instance
+
+        with pytest.raises(FileNotFoundError, match="No cached stock data"):
+            load_cached_stocks("SPY")
+
+    @patch("optopsy.data.providers.cache.ParquetCache", autospec=True)
+    def test_quote_date_is_datetime(self, MockCache):
+        """quote_date column should be datetime64."""
+        mock_instance = MagicMock()
+        mock_instance.read.return_value = self._make_cached_stock_df()
+        MockCache.return_value = mock_instance
+
+        result = load_cached_stocks("SPY")
+        assert pd.api.types.is_datetime64_any_dtype(result["quote_date"])
+
+    def test_accessible_from_public_api(self):
+        """load_cached_stocks is accessible via op.load_cached_stocks."""
+        assert hasattr(op, "load_cached_stocks")
+        assert op.load_cached_stocks is load_cached_stocks

--- a/tests/test_signals_core.py
+++ b/tests/test_signals_core.py
@@ -1,4 +1,4 @@
-"""Tests for signal combinators, Signal class, sustained(), custom_signal(), and edge cases."""
+"""Tests for signal combinators, Signal class, sustained(), custom_signal(), signal_dates(), and edge cases."""
 
 import pandas as pd
 import pytest
@@ -6,12 +6,12 @@ import pytest
 from optopsy.signals import (
     Signal,
     and_signals,
-    apply_signal,
     custom_signal,
     day_of_week,
     or_signals,
     rsi_below,
     signal,
+    signal_dates,
     sma_above,
     sma_below,
     sustained,
@@ -137,10 +137,10 @@ class TestSignalClass:
         # Monday AND Tuesday — no single day can be both
         assert not result.any()
 
-    def test_signal_accepted_via_apply_signal(self, option_data_entry_exit):
-        """Signal object accepted by apply_signal and used as entry_dates."""
+    def test_signal_accepted_via_signal_dates(self, option_data_entry_exit):
+        """Signal object accepted by signal_dates and used as entry_dates."""
         sig = Signal(day_of_week(3))  # Thursday
-        entry_dates = apply_signal(option_data_entry_exit, sig)
+        entry_dates = signal_dates(option_data_entry_exit, sig)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -151,13 +151,13 @@ class TestSignalClass:
         assert isinstance(results, pd.DataFrame)
 
     def test_signal_combined_with_callable(self, option_data_entry_exit):
-        """Signal combined with another Signal and used via apply_signal works."""
+        """Signal combined with another Signal and used via signal_dates works."""
 
         def always_true(data):
             return pd.Series(True, index=data.index)
 
         sig = Signal(day_of_week(3)) & Signal(always_true)
-        entry_dates = apply_signal(option_data_entry_exit, sig)
+        entry_dates = signal_dates(option_data_entry_exit, sig)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -312,14 +312,14 @@ class TestSustainedSignal:
         flagged_days = price_data.loc[result, "quote_date"].dt.dayofweek
         assert (flagged_days == 0).all()
 
-    def test_sustained_accepted_via_apply_signal(self, option_data_entry_exit):
-        """sustained() output is accepted by apply_signal and used as entry_dates."""
+    def test_sustained_accepted_via_signal_dates(self, option_data_entry_exit):
+        """sustained() output is accepted by signal_dates and used as entry_dates."""
 
         def always_true(d):
             return pd.Series(True, index=d.index)
 
         sig = sustained(always_true, days=1)
-        entry_dates = apply_signal(option_data_entry_exit, sig)
+        entry_dates = signal_dates(option_data_entry_exit, sig)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -379,123 +379,6 @@ class TestSignalEdgeCases:
         assert not result_macd.any(), (
             "macd_cross_above should return all-False with no price column"
         )
-
-    def test_apply_signal_no_duplicate_when_close_provided(self):
-        """apply_signal must NOT add underlying_price when input already has close."""
-        dates = pd.date_range("2018-01-01", periods=5, freq="B")
-        data = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "close": [100.0, 101.0, 102.0, 103.0, 104.0],
-            }
-        )
-        seen_columns: list = []
-
-        def capture_columns(df):
-            seen_columns.append(set(df.columns))
-            return pd.Series(True, index=df.index)
-
-        apply_signal(data, capture_columns)
-        assert "close" in seen_columns[0]
-        assert "underlying_price" not in seen_columns[0]
-
-    def test_apply_signal_stock_data_merges_close(self):
-        """apply_signal with stock_data should merge close into options data."""
-        dates = pd.date_range("2018-01-01", periods=60, freq="B")
-        options = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "strike": [100.0] * 60,
-                "option_type": ["c"] * 60,
-                "implied_volatility": [0.20 + i * 0.005 for i in range(60)],
-                "expiration": dates + pd.Timedelta(days=30),
-            }
-        )
-        stock = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "close": [100.0] * 60,
-            }
-        )
-        # Without stock_data, IV rank has no price column → all-False
-        from optopsy.signals import iv_rank_above
-
-        result_without = apply_signal(options, iv_rank_above(threshold=0.1, window=20))
-        assert result_without.empty
-
-        # With stock_data, close is merged → IV rank can compute
-        result_with = apply_signal(
-            options, iv_rank_above(threshold=0.1, window=20), stock_data=stock
-        )
-        assert not result_with.empty
-
-    def test_apply_signal_stock_data_ignored_when_close_exists(self):
-        """stock_data should be ignored when data already has close."""
-        dates = pd.date_range("2018-01-01", periods=5, freq="B")
-        data = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "close": [100.0, 101.0, 102.0, 103.0, 104.0],
-            }
-        )
-        # stock_data with different prices — should be ignored
-        stock = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "close": [999.0] * 5,
-            }
-        )
-        seen_prices: list = []
-
-        def capture_close(df):
-            seen_prices.append(df["close"].iloc[0])
-            return pd.Series(True, index=df.index)
-
-        apply_signal(data, capture_close, stock_data=stock)
-        assert seen_prices[0] == 100.0  # original close, not stock_data
-
-    def test_apply_signal_stock_data_accepts_yfinance_format(self):
-        """stock_data should accept yfinance-style DataFrames."""
-        dates = pd.date_range("2018-01-01", periods=5, freq="B")
-        options = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "strike": [100.0] * 5,
-            }
-        )
-        # yfinance style: DatetimeIndex, capitalized columns, no underlying_symbol
-        stock = pd.DataFrame(
-            {"Close": [100.0, 101.0, 102.0, 103.0, 104.0]},
-            index=dates,
-        )
-        stock.index.name = "Date"
-        seen_columns: list = []
-
-        def capture(df):
-            seen_columns.append(set(df.columns))
-            return pd.Series(True, index=df.index)
-
-        apply_signal(options, capture, stock_data=stock)
-        assert "close" in seen_columns[0]
-
-    def test_apply_signal_stock_data_none_is_noop(self):
-        """stock_data=None should behave like the original apply_signal."""
-        dates = pd.date_range("2018-01-01", periods=5, freq="B")
-        data = pd.DataFrame(
-            {
-                "underlying_symbol": "SPX",
-                "quote_date": dates,
-                "close": [100.0, 101.0, 102.0, 103.0, 104.0],
-            }
-        )
-        result = apply_signal(data, sma_below(period=3), stock_data=None)
-        assert isinstance(result, pd.DataFrame)
 
     def test_sustained_days_zero_raises(self):
         """sustained() with days < 1 should raise ValueError."""
@@ -558,10 +441,10 @@ class TestCustomSignal:
         result = sig(df)
         assert result.tolist() == [True, False, True, False]
 
-    def test_apply_signal_integration(self, flagged_df):
-        """custom_signal() returned SignalFunc should work with apply_signal()."""
+    def test_signal_dates_integration(self, flagged_df):
+        """custom_signal() returned SignalFunc should work with signal_dates()."""
         sig = custom_signal(flagged_df)
-        result = apply_signal(flagged_df, sig)
+        result = signal_dates(flagged_df, sig)
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == ["underlying_symbol", "quote_date"]
         assert len(result) == 2  # only dates where flag is True
@@ -571,7 +454,7 @@ class TestCustomSignal:
         }
 
     def test_all_false_returns_empty(self):
-        """All-False flag column should produce an empty result from apply_signal."""
+        """All-False flag column should produce an empty result from signal_dates."""
         df = pd.DataFrame(
             {
                 "underlying_symbol": ["SPY", "SPY"],
@@ -580,7 +463,7 @@ class TestCustomSignal:
             }
         )
         sig = custom_signal(df)
-        result = apply_signal(df, sig)
+        result = signal_dates(df, sig)
         assert result.empty
 
     def test_all_true_returns_all_dates(self, flagged_df):
@@ -588,7 +471,7 @@ class TestCustomSignal:
         df = flagged_df.copy()
         df["signal"] = True
         sig = custom_signal(df)
-        result = apply_signal(df, sig)
+        result = signal_dates(df, sig)
         assert len(result) == len(df)
 
     def test_composable_with_and_signals(self, flagged_df):
@@ -598,14 +481,14 @@ class TestCustomSignal:
         # 2018-01-03 is Wednesday, flagged False → not in result
         # 2018-01-04 is Thursday, flagged True → not in result (not Tuesday)
         sig = and_signals(custom_signal(flagged_df), day_of_week(1))
-        result = apply_signal(flagged_df, sig)
+        result = signal_dates(flagged_df, sig)
         assert len(result) == 1
         assert result.iloc[0]["quote_date"] == pd.Timestamp("2018-01-02")
 
     def test_composable_with_signal_class(self, flagged_df):
         """custom_signal() result should compose with the Signal fluent API."""
         sig = signal(custom_signal(flagged_df)) & signal(day_of_week(1))
-        result = apply_signal(flagged_df, sig)
+        result = signal_dates(flagged_df, sig)
         assert len(result) == 1
         assert result.iloc[0]["quote_date"] == pd.Timestamp("2018-01-02")
 
@@ -690,3 +573,116 @@ class TestCustomSignal:
 
         assert hasattr(op, "custom_signal")
         assert callable(op.custom_signal)
+
+
+# ============================================================================
+# signal_dates()
+# ============================================================================
+
+
+class TestSignalDates:
+    """Tests for signal_dates() — the recommended way to generate entry/exit dates."""
+
+    @pytest.fixture
+    def stock_data(self):
+        """Stock OHLCV data with a clear SMA crossover."""
+        dates = pd.date_range("2018-01-01", periods=30, freq="B")
+        # Price starts at 100, drops to ~85, then recovers
+        prices = [100 - i for i in range(15)] + [86 + i for i in range(15)]
+        return pd.DataFrame(
+            {
+                "underlying_symbol": "SPY",
+                "quote_date": dates,
+                "close": prices,
+            }
+        )
+
+    def test_returns_symbol_and_date_columns(self, stock_data):
+        """signal_dates should return DataFrame with (underlying_symbol, quote_date)."""
+        result = signal_dates(stock_data, sma_below(period=5))
+        assert list(result.columns) == ["underlying_symbol", "quote_date"]
+
+    def test_filters_to_true_dates_only(self, stock_data):
+        """Only dates where the signal is True should be returned."""
+        # day_of_week(0) = Monday — roughly 1/5 of business days
+        result = signal_dates(stock_data, day_of_week(0))
+        assert not result.empty
+        assert all(result["quote_date"].dt.dayofweek == 0)
+
+    def test_all_false_returns_empty(self):
+        """Signal that's always False returns empty DataFrame."""
+        dates = pd.date_range("2018-01-01", periods=5, freq="B")
+        data = pd.DataFrame(
+            {
+                "underlying_symbol": "SPY",
+                "quote_date": dates,
+                "close": [100.0] * 5,
+            }
+        )
+
+        def always_false(df):
+            return pd.Series(False, index=df.index)
+
+        result = signal_dates(data, always_false)
+        assert result.empty
+        assert list(result.columns) == ["underlying_symbol", "quote_date"]
+
+    def test_composed_signal_with_operators(self, stock_data):
+        """Composed signals via Signal & operator should work."""
+        sig = signal(day_of_week(0)) & signal(sma_below(period=5))
+        result = signal_dates(stock_data, sig)
+        assert isinstance(result, pd.DataFrame)
+        if not result.empty:
+            assert all(result["quote_date"].dt.dayofweek == 0)
+
+    def test_deduplicates_dates(self):
+        """Duplicate (symbol, date) rows in input should not produce duplicates."""
+        dates = pd.date_range("2018-01-01", periods=3, freq="B")
+        # Duplicate each row
+        data = pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY"] * 6,
+                "quote_date": list(dates) * 2,
+                "close": [100.0, 101.0, 102.0, 100.0, 101.0, 102.0],
+            }
+        )
+
+        def always_true(df):
+            return pd.Series(True, index=df.index)
+
+        result = signal_dates(data, always_true)
+        assert len(result) == 3  # 3 unique dates, not 6
+
+    def test_multi_symbol(self):
+        """signal_dates should work with multi-symbol stock data."""
+        dates = pd.date_range("2018-01-01", periods=5, freq="B")
+        data = pd.DataFrame(
+            {
+                "underlying_symbol": ["SPY"] * 5 + ["QQQ"] * 5,
+                "quote_date": list(dates) * 2,
+                "close": [100.0] * 5 + [200.0] * 5,
+            }
+        )
+        result = signal_dates(data, day_of_week(0))
+        # Both symbols should have Mondays
+        assert set(result["underlying_symbol"]) == {"SPY", "QQQ"}
+
+    def test_no_options_data_required(self):
+        """signal_dates should work with stock data only — no options data needed."""
+        dates = pd.date_range("2018-01-01", periods=5, freq="B")
+        stock_only = pd.DataFrame(
+            {
+                "underlying_symbol": "SPY",
+                "quote_date": dates,
+                "close": [100.0, 101.0, 102.0, 103.0, 104.0],
+            }
+        )
+        result = signal_dates(stock_only, day_of_week(0))
+        assert isinstance(result, pd.DataFrame)
+
+    def test_accessible_from_public_api(self):
+        """signal_dates is accessible via op.signal_dates."""
+        import optopsy as op
+
+        assert hasattr(op, "signal_dates")
+        assert op.signal_dates is signal_dates

--- a/tests/test_signals_integration.py
+++ b/tests/test_signals_integration.py
@@ -7,11 +7,11 @@ import pytest
 
 from optopsy.signals import (
     and_signals,
-    apply_signal,
     atr_above,
     day_of_week,
     rsi_above,
     rsi_below,
+    signal_dates,
     sma_above,
     sustained,
 )
@@ -119,7 +119,7 @@ class TestEntrySignalIntegration:
         )
 
         # With Thursday-only dates
-        entry_dates = apply_signal(option_data_entry_exit, day_of_week(3))
+        entry_dates = signal_dates(option_data_entry_exit, day_of_week(3))
         results_thu = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -135,7 +135,7 @@ class TestEntrySignalIntegration:
     def test_signal_filters_no_match_returns_empty(self, option_data_entry_exit):
         """entry_dates with no matches should return empty DataFrame."""
         # Saturday signal on weekday data -> no matches
-        entry_dates = apply_signal(option_data_entry_exit, day_of_week(5))
+        entry_dates = signal_dates(option_data_entry_exit, day_of_week(5))
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -156,7 +156,7 @@ class TestEntrySignalIntegration:
             raw=True,
         )
 
-        entry_dates = apply_signal(option_data_entry_exit, always_true_signal)
+        entry_dates = signal_dates(option_data_entry_exit, always_true_signal)
         results_true_signal = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -169,7 +169,7 @@ class TestEntrySignalIntegration:
 
     def test_entry_dates_with_short_puts(self, option_data_entry_exit):
         """entry_dates should work with short put strategies too."""
-        entry_dates = apply_signal(option_data_entry_exit, day_of_week(3))
+        entry_dates = signal_dates(option_data_entry_exit, day_of_week(3))
         results = short_puts(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -198,7 +198,7 @@ class TestEntrySignalIntegration:
         # Combine Thursday + always True (effectively just Thursday)
         combined = and_signals(day_of_week(3), always_true_signal)
 
-        entry_dates_combined = apply_signal(option_data_entry_exit, combined)
+        entry_dates_combined = signal_dates(option_data_entry_exit, combined)
         results_combined = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -207,7 +207,7 @@ class TestEntrySignalIntegration:
             raw=True,
         )
 
-        entry_dates_thu = apply_signal(option_data_entry_exit, day_of_week(3))
+        entry_dates_thu = signal_dates(option_data_entry_exit, day_of_week(3))
         results_thu = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -237,7 +237,7 @@ class TestExitSignalIntegration:
 
         # With exit dates that match the exit date (Saturday Feb 3 -> dayofweek=5)
         # The expiration date 2018-02-03 is a Saturday
-        exit_dates = apply_signal(option_data_entry_exit, day_of_week(5))
+        exit_dates = signal_dates(option_data_entry_exit, day_of_week(5))
         results_sat = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -252,7 +252,7 @@ class TestExitSignalIntegration:
     def test_exit_dates_no_match_returns_empty(self, option_data_entry_exit):
         """exit_dates with no matches should return empty DataFrame."""
         # The exit date (2018-02-03) is Saturday. Filter for Monday exits only.
-        exit_dates = apply_signal(option_data_entry_exit, day_of_week(0))
+        exit_dates = signal_dates(option_data_entry_exit, day_of_week(0))
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -273,7 +273,7 @@ class TestExitSignalIntegration:
             raw=True,
         )
 
-        exit_dates = apply_signal(option_data_entry_exit, always_true_signal)
+        exit_dates = signal_dates(option_data_entry_exit, always_true_signal)
         results_true_signal = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -289,7 +289,7 @@ class TestExitSignalIntegration:
     ):
         """entry_dates and exit_dates should both be applied independently."""
         # Entry on Thursday only, exit any time
-        entry_dates = apply_signal(option_data_entry_exit, day_of_week(3))
+        entry_dates = signal_dates(option_data_entry_exit, day_of_week(3))
         results_entry_only = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -299,7 +299,7 @@ class TestExitSignalIntegration:
         )
 
         # Entry on Thursday, exit dates always true (no additional filtering)
-        exit_dates = apply_signal(option_data_entry_exit, always_true_signal)
+        exit_dates = signal_dates(option_data_entry_exit, always_true_signal)
         results_both = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -322,7 +322,7 @@ class TestExitSignalIntegration:
             raw=True,
         )
 
-        exit_dates = apply_signal(option_data_entry_exit, always_true_signal)
+        exit_dates = signal_dates(option_data_entry_exit, always_true_signal)
         results_with_dates = short_puts(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -352,7 +352,7 @@ class TestExitSignalIntegration:
         def price_above_215(data):
             return data["close"] > 215
 
-        exit_dates = apply_signal(stock_data_spx, price_above_215)
+        exit_dates = signal_dates(stock_data_spx, price_above_215)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -381,7 +381,7 @@ class TestExitSignalIntegration:
         def price_above_225(data):
             return data["close"] > 225
 
-        exit_dates = apply_signal(stock_data_spx, price_above_225)
+        exit_dates = signal_dates(stock_data_spx, price_above_225)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -471,7 +471,7 @@ class TestExitDteTolerance:
 
     def test_tolerance_with_exit_dates(self, sparse_exit_data, always_true_signal):
         """exit_dte_tolerance should work alongside exit_dates."""
-        exit_dates = apply_signal(sparse_exit_data, always_true_signal)
+        exit_dates = signal_dates(sparse_exit_data, always_true_signal)
         results = long_calls(
             sparse_exit_data,
             max_entry_dte=90,
@@ -484,7 +484,7 @@ class TestExitDteTolerance:
 
     def test_tolerance_with_entry_dates(self, sparse_exit_data, always_true_signal):
         """exit_dte_tolerance should work alongside entry_dates."""
-        entry_dates = apply_signal(sparse_exit_data, always_true_signal)
+        entry_dates = signal_dates(sparse_exit_data, always_true_signal)
         results = long_calls(
             sparse_exit_data,
             max_entry_dte=90,
@@ -518,12 +518,12 @@ class TestExitDteTolerance:
 
 
 # ============================================================================
-# apply_signal() tests
+# signal_dates() tests
 # ============================================================================
 
 
-class TestApplySignal:
-    """Tests for the apply_signal() function that decouples signal computation."""
+class TestSignalDates:
+    """Tests for the signal_dates() function that decouples signal computation."""
 
     @pytest.fixture
     def ohlcv_stock_data(self):
@@ -545,64 +545,64 @@ class TestApplySignal:
             }
         )
 
-    def test_apply_signal_returns_dates_dataframe(self, ohlcv_stock_data):
-        """apply_signal should return a DataFrame with (underlying_symbol, quote_date)."""
+    def test_signal_dates_returns_dates_dataframe(self, ohlcv_stock_data):
+        """signal_dates should return a DataFrame with (underlying_symbol, quote_date)."""
 
         def always_true(d):
             return pd.Series(True, index=d.index)
 
-        result = apply_signal(ohlcv_stock_data, always_true)
+        result = signal_dates(ohlcv_stock_data, always_true)
         assert isinstance(result, pd.DataFrame)
         assert "underlying_symbol" in result.columns
         assert "quote_date" in result.columns
         assert len(result.columns) == 2
 
-    def test_apply_signal_close_maps_to_underlying_price(self, ohlcv_stock_data):
-        """apply_signal should auto-map 'close' to 'underlying_price' for TA signals."""
+    def test_signal_dates_close_maps_to_underlying_price(self, ohlcv_stock_data):
+        """signal_dates should auto-map 'close' to 'underlying_price' for TA signals."""
         # This signal reads underlying_price — should work when only close is present
         sig = sma_above(period=10)
-        result = apply_signal(ohlcv_stock_data, sig)
+        result = signal_dates(ohlcv_stock_data, sig)
         assert isinstance(result, pd.DataFrame)
 
-    def test_apply_signal_all_true_returns_all_dates(self, ohlcv_stock_data):
-        """apply_signal with always-true signal returns all unique dates."""
+    def test_signal_dates_all_true_returns_all_dates(self, ohlcv_stock_data):
+        """signal_dates with always-true signal returns all unique dates."""
 
         def always_true(d):
             return pd.Series(True, index=d.index)
 
-        result = apply_signal(ohlcv_stock_data, always_true)
+        result = signal_dates(ohlcv_stock_data, always_true)
         n_unique = ohlcv_stock_data.drop_duplicates(
             ["underlying_symbol", "quote_date"]
         ).shape[0]
         assert len(result) == n_unique
 
-    def test_apply_signal_all_false_returns_empty(self, ohlcv_stock_data):
-        """apply_signal with always-false signal returns empty DataFrame."""
+    def test_signal_dates_all_false_returns_empty(self, ohlcv_stock_data):
+        """signal_dates with always-false signal returns empty DataFrame."""
 
         def always_false(d):
             return pd.Series(False, index=d.index)
 
-        result = apply_signal(ohlcv_stock_data, always_false)
+        result = signal_dates(ohlcv_stock_data, always_false)
         assert len(result) == 0
         assert "underlying_symbol" in result.columns
         assert "quote_date" in result.columns
 
-    def test_apply_signal_date_only_signal(self, ohlcv_stock_data):
-        """Date-based signals (e.g. day_of_week) work with apply_signal."""
-        result = apply_signal(ohlcv_stock_data, day_of_week(3))
+    def test_signal_dates_date_only_signal(self, ohlcv_stock_data):
+        """Date-based signals (e.g. day_of_week) work with signal_dates."""
+        result = signal_dates(ohlcv_stock_data, day_of_week(3))
         assert isinstance(result, pd.DataFrame)
         # All flagged dates should be Thursdays
         assert (result["quote_date"].dt.dayofweek == 3).all()
 
-    def test_apply_signal_entry_dates_accepted_by_strategy(
+    def test_signal_dates_entry_dates_accepted_by_strategy(
         self, option_data_entry_exit, ohlcv_stock_data
     ):
-        """entry_dates from apply_signal are accepted by strategy functions."""
+        """entry_dates from signal_dates are accepted by strategy functions."""
 
         def always_true(d):
             return pd.Series(True, index=d.index)
 
-        entry_dates = apply_signal(ohlcv_stock_data, always_true)
+        entry_dates = signal_dates(ohlcv_stock_data, always_true)
         results = long_calls(
             option_data_entry_exit,
             max_entry_dte=90,
@@ -612,22 +612,22 @@ class TestApplySignal:
         )
         assert isinstance(results, pd.DataFrame)
 
-    def test_apply_signal_with_combined_signal(self, ohlcv_stock_data):
-        """apply_signal works with combined signals (and_signals, Signal class)."""
+    def test_signal_dates_with_combined_signal(self, ohlcv_stock_data):
+        """signal_dates works with combined signals (and_signals, Signal class)."""
 
         def always_true(d):
             return pd.Series(True, index=d.index)
 
         combined = and_signals(day_of_week(0, 1, 2, 3, 4), always_true)
-        result = apply_signal(ohlcv_stock_data, combined)
+        result = signal_dates(ohlcv_stock_data, combined)
         assert isinstance(result, pd.DataFrame)
 
-    def test_apply_signal_with_signal_class(self, ohlcv_stock_data):
-        """apply_signal works with Signal objects."""
+    def test_signal_dates_with_signal_class(self, ohlcv_stock_data):
+        """signal_dates works with Signal objects."""
         from optopsy.signals import signal
 
         sig = signal(day_of_week(3)) & signal(day_of_week(0, 1, 2, 3, 4))
-        result = apply_signal(ohlcv_stock_data, sig)
+        result = signal_dates(ohlcv_stock_data, sig)
         assert (result["quote_date"].dt.dayofweek == 3).all()
 
     def test_atr_uses_real_high_low_when_available(self, ohlcv_stock_data):
@@ -698,7 +698,7 @@ class TestApplySignal:
 class TestTASignalE2E:
     """
     End-to-end tests that exercise the full pipeline:
-    real pandas_ta signal + apply_signal() → entry_dates/exit_dates → strategy output.
+    real pandas_ta signal + signal_dates() → entry_dates/exit_dates → strategy output.
     """
 
     def _get_entry_dates(self, stock_data_long_history):
@@ -737,7 +737,7 @@ class TestTASignalE2E:
         )
         assert len(results_all) > 0
 
-        entry_dates = apply_signal(stock_data_long_history, sma_above(20))
+        entry_dates = signal_dates(stock_data_long_history, sma_above(20))
         results_sma = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -757,7 +757,7 @@ class TestTASignalE2E:
         """rsi_below(14, 30) entry_dates should only keep decline-phase entries."""
         ed = self._get_entry_dates(stock_data_long_history)
 
-        entry_dates = apply_signal(stock_data_long_history, rsi_below(14, 30))
+        entry_dates = signal_dates(stock_data_long_history, rsi_below(14, 30))
         results = short_puts(
             option_data_with_stock,
             max_entry_dte=365,
@@ -785,7 +785,7 @@ class TestTASignalE2E:
         )
         assert len(results_all) > 0
 
-        exit_dates = apply_signal(stock_data_long_history, rsi_above(14, 70))
+        exit_dates = signal_dates(stock_data_long_history, rsi_above(14, 70))
         results_exit = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -800,7 +800,7 @@ class TestTASignalE2E:
         assert set(results_exit["expiration"].unique()) == {exps["B"]}
 
         # Inverse: rsi_below(14, 30) keeps only exp-A exits
-        exit_dates_inv = apply_signal(stock_data_long_history, rsi_below(14, 30))
+        exit_dates_inv = signal_dates(stock_data_long_history, rsi_below(14, 30))
         results_inverse = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -820,8 +820,8 @@ class TestTASignalE2E:
         ed = self._get_entry_dates(stock_data_long_history)
         exps = self._exp_dates(stock_data_long_history)
 
-        entry_dates = apply_signal(stock_data_long_history, rsi_below(14, 30))
-        exit_dates = apply_signal(stock_data_long_history, rsi_above(14, 70))
+        entry_dates = signal_dates(stock_data_long_history, rsi_below(14, 30))
+        exit_dates = signal_dates(stock_data_long_history, rsi_above(14, 70))
         results = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -860,14 +860,14 @@ class TestTASignalE2E:
         assert len(results) < len(results_entry_only)
         assert len(results) < len(results_exit_only)
 
-    def test_sustained_ta_signal_with_apply_signal(
+    def test_sustained_ta_signal_with_signal_dates(
         self, option_data_with_stock, stock_data_long_history
     ):
         """sustained(rsi_below(14, 30), days=3) must reject bar 55."""
         decline_deep = {pd.Timestamp(stock_data_long_history["quote_date"].values[30])}
 
         # Plain rsi_below keeps both decline entries
-        entry_dates_plain = apply_signal(stock_data_long_history, rsi_below(14, 30))
+        entry_dates_plain = signal_dates(stock_data_long_history, rsi_below(14, 30))
         results_plain = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -878,7 +878,7 @@ class TestTASignalE2E:
         assert len(results_plain) > 0
 
         # sustained(days=3) rejects bar 55 (streak < 3 bars)
-        entry_dates_sust = apply_signal(
+        entry_dates_sust = signal_dates(
             stock_data_long_history, sustained(rsi_below(14, 30), days=3)
         )
         results_sustained = long_calls(
@@ -904,7 +904,7 @@ class TestTASignalE2E:
         sd_full = stock_data_long_history
         sd_close_only = sd_full.drop(columns=["high", "low"])
 
-        entry_dates_ohlcv = apply_signal(sd_full, atr_above(period=14, multiplier=1.0))
+        entry_dates_ohlcv = signal_dates(sd_full, atr_above(period=14, multiplier=1.0))
         results_ohlcv = long_calls(
             option_data_with_stock,
             max_entry_dte=365,
@@ -913,7 +913,7 @@ class TestTASignalE2E:
             raw=True,
         )
 
-        entry_dates_close = apply_signal(
+        entry_dates_close = signal_dates(
             sd_close_only, atr_above(period=14, multiplier=1.0)
         )
         results_close = long_calls(

--- a/tests/test_signals_iv.py
+++ b/tests/test_signals_iv.py
@@ -9,9 +9,9 @@ import optopsy as op
 from optopsy.signals import (
     _compute_atm_iv,
     _compute_iv_rank_series,
-    apply_signal,
     iv_rank_above,
     iv_rank_below,
+    signal_dates,
 )
 
 # ============================================================================
@@ -336,38 +336,38 @@ class TestIVRankEdgeCases:
 
 
 # ============================================================================
-# Tests for apply_signal with IV rank
+# Tests for signal_dates with IV rank signals
 # ============================================================================
 
 
-class TestApplySignalWithIVRank:
-    def test_apply_signal_with_iv_rank(self, options_data_with_iv):
-        """apply_signal should work with IV rank signals on options data."""
+class TestSignalDatesWithIVRank:
+    def test_signal_dates_with_iv_rank(self, options_data_with_iv):
+        """signal_dates should work with IV rank signals on options data."""
         sig = iv_rank_above(threshold=0.5, window=20)
-        result = apply_signal(options_data_with_iv, sig)
+        result = signal_dates(options_data_with_iv, sig)
         assert isinstance(result, pd.DataFrame)
         assert "underlying_symbol" in result.columns
         assert "quote_date" in result.columns
         assert len(result) > 0
 
-    def test_apply_signal_iv_rank_below(self, options_data_with_iv):
-        """apply_signal should work with iv_rank_below."""
+    def test_signal_dates_iv_rank_below(self, options_data_with_iv):
+        """signal_dates should work with iv_rank_below."""
         sig = iv_rank_below(threshold=0.3, window=252)
-        result = apply_signal(options_data_with_iv, sig)
+        result = signal_dates(options_data_with_iv, sig)
         assert isinstance(result, pd.DataFrame)
 
-    def test_apply_signal_no_iv_returns_empty(self, options_data_no_iv):
-        """apply_signal with IV signal on data without IV returns empty."""
+    def test_signal_dates_no_iv_returns_empty(self, options_data_no_iv):
+        """signal_dates with IV signal on data without IV returns empty."""
         sig = iv_rank_above(threshold=0.5)
-        result = apply_signal(options_data_no_iv, sig)
+        result = signal_dates(options_data_no_iv, sig)
         assert len(result) == 0
 
     def test_high_threshold_fewer_dates(self, options_data_with_iv):
         """Higher threshold should produce fewer valid dates."""
-        dates_50 = apply_signal(
+        dates_50 = signal_dates(
             options_data_with_iv, iv_rank_above(threshold=0.5, window=20)
         )
-        dates_80 = apply_signal(
+        dates_80 = signal_dates(
             options_data_with_iv, iv_rank_above(threshold=0.8, window=20)
         )
         assert len(dates_80) <= len(dates_50)

--- a/tests/test_simulator_e2e.py
+++ b/tests/test_simulator_e2e.py
@@ -16,9 +16,9 @@ import pytest
 import optopsy as op
 from optopsy.signals import (
     and_signals,
-    apply_signal,
     day_of_week,
     or_signals,
+    signal_dates,
     sma_above,
 )
 from optopsy.simulator import _TRADE_LOG_COLUMNS, SimulationResult
@@ -464,7 +464,7 @@ class TestSelectorsE2E:
 def stock_data(chain_data):
     """Build a stock price DataFrame from the chain data for signal computation.
 
-    apply_signal needs: underlying_symbol, quote_date, underlying_price.
+    signal_dates needs: underlying_symbol, quote_date, underlying_price.
     We extract unique (symbol, date, price) rows from the option chain.
     """
     stock = (
@@ -481,7 +481,7 @@ class TestSignalEntryE2E:
 
     def test_day_of_week_filters_entries(self, chain_data, stock_data):
         """day_of_week(3) = Thursday only allows Feb 1 entry."""
-        entry_dates = apply_signal(stock_data, day_of_week(3))  # Thursday
+        entry_dates = signal_dates(stock_data, day_of_week(3))  # Thursday
         result = op.simulate(
             chain_data, op.long_calls, entry_dates=entry_dates, max_positions=10
         )
@@ -493,7 +493,7 @@ class TestSignalEntryE2E:
 
     def test_day_of_week_tuesday_allows_two_entries(self, chain_data, stock_data):
         """day_of_week(1) = Tuesday allows Jan 2 and Jan 16 entries."""
-        entry_dates = apply_signal(stock_data, day_of_week(1))  # Tuesday
+        entry_dates = signal_dates(stock_data, day_of_week(1))  # Tuesday
         result = op.simulate(
             chain_data, op.long_calls, entry_dates=entry_dates, max_positions=10
         )
@@ -501,7 +501,7 @@ class TestSignalEntryE2E:
 
     def test_no_matching_signal_returns_empty(self, chain_data, stock_data):
         """day_of_week(4) = Friday — no entries on Friday → empty result."""
-        entry_dates = apply_signal(stock_data, day_of_week(4))  # Friday
+        entry_dates = signal_dates(stock_data, day_of_week(4))  # Friday
         result = op.simulate(chain_data, op.long_calls, entry_dates=entry_dates)
         assert len(result.trade_log) == 0
         assert result.summary["total_trades"] == 0
@@ -509,7 +509,7 @@ class TestSignalEntryE2E:
     def test_or_signals_union(self, chain_data, stock_data):
         """or_signals(Tuesday, Thursday) allows all 3 entries."""
         sig = or_signals(day_of_week(1), day_of_week(3))
-        entry_dates = apply_signal(stock_data, sig)
+        entry_dates = signal_dates(stock_data, sig)
         result = op.simulate(
             chain_data, op.long_calls, entry_dates=entry_dates, max_positions=10
         )
@@ -518,14 +518,14 @@ class TestSignalEntryE2E:
     def test_and_signals_intersection(self, chain_data, stock_data):
         """and_signals(Tuesday, Thursday) — impossible, empty result."""
         sig = and_signals(day_of_week(1), day_of_week(3))
-        entry_dates = apply_signal(stock_data, sig)
+        entry_dates = signal_dates(stock_data, sig)
         result = op.simulate(chain_data, op.long_calls, entry_dates=entry_dates)
         assert len(result.trade_log) == 0
 
     def test_signal_with_position_limits(self, chain_data, stock_data):
         """Tuesday signal gives 2 entries, but max_positions=1 and they overlap
         (Jan 16 entry < Jan 31 exit), so only 1 trade executes."""
-        entry_dates = apply_signal(stock_data, day_of_week(1))
+        entry_dates = signal_dates(stock_data, day_of_week(1))
         result = op.simulate(
             chain_data, op.long_calls, entry_dates=entry_dates, max_positions=1
         )
@@ -534,7 +534,7 @@ class TestSignalEntryE2E:
     def test_signal_pnl_matches_unfiltered(self, chain_data, stock_data):
         """Thursday-only signal picks the same trade as the Feb 1 entry
         in the unfiltered run. Verify P&L matches."""
-        entry_dates = apply_signal(stock_data, day_of_week(3))
+        entry_dates = signal_dates(stock_data, day_of_week(3))
 
         # Signal-filtered: only the Feb 1 trade
         r_signal = op.simulate(chain_data, op.long_calls, entry_dates=entry_dates)
@@ -569,7 +569,7 @@ class TestSignalEntryE2E:
             }
         )
         # SMA(5) on monotonically rising prices → price always above SMA
-        entry_dates = apply_signal(stock, sma_above(5))
+        entry_dates = signal_dates(stock, sma_above(5))
         result = op.simulate(
             chain_data, op.long_calls, entry_dates=entry_dates, max_positions=10
         )

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -10,7 +10,7 @@ import datetime
 import pandas as pd
 import pytest
 
-from optopsy.signals import apply_signal, day_of_week
+from optopsy.signals import day_of_week, signal_dates
 from optopsy.strategies import long_calls
 from optopsy.timestamps import normalize_dates
 
@@ -98,23 +98,23 @@ class TestCrossSourceDateMatching:
     def test_naive_signals_match(self, option_data):
         """Baseline: naive midnight signals match naive midnight options."""
         signal_data = self._make_signal_data()
-        entry_dates = apply_signal(signal_data, day_of_week(3))
+        entry_dates = signal_dates(signal_data, day_of_week(3))
         result = long_calls(option_data, entry_dates=entry_dates, raw=True)
         assert len(result) > 0
 
     def test_tz_aware_with_time_signals_match(self, option_data):
         """UTC tz-aware signals at market close match naive midnight options."""
         signal_data = self._make_signal_data(tz="UTC", hour=16, minute=30)
-        entry_dates = apply_signal(signal_data, day_of_week(3))
+        entry_dates = signal_dates(signal_data, day_of_week(3))
         result = long_calls(option_data, entry_dates=entry_dates, raw=True)
         assert len(result) > 0
 
 
-class TestApplySignalNormalization:
-    """apply_signal output is always normalized."""
+class TestSignalDatesNormalization:
+    """signal_dates output is always normalized."""
 
     def test_normalizes_tz_and_time(self):
-        """apply_signal strips timezone and time from output dates."""
+        """signal_dates strips timezone and time from output dates."""
         data = pd.DataFrame(
             {
                 "underlying_symbol": ["SPX"] * 3,
@@ -128,6 +128,6 @@ class TestApplySignalNormalization:
                 "close": [100, 101, 102],
             }
         )
-        result = apply_signal(data, lambda df: pd.Series(True, index=df.index))
+        result = signal_dates(data, lambda df: pd.Series(True, index=df.index))
         assert result["quote_date"].dt.tz is None
         assert all(result["quote_date"].dt.hour == 0)


### PR DESCRIPTION
## Summary

- **`options_data(df)`** — validates/normalizes an existing DataFrame for use with strategies (no CSV or column-index mapping needed)
- **`load_cached_options(symbol)`** — reads options data from the parquet cache (produced by `optopsy-data download`) into the strategy pipeline
- **`load_cached_stocks(symbol)`** — reads cached stock OHLCV data for signal building
- **`signal_dates(stock_data, signal_func)`** — replaces `apply_signal` as the single way to generate entry/exit dates from signals

Removes `apply_signal` which confusingly required options data to build stock-based signals. `signal_dates` cleanly separates concerns: signals run on stock data, strategies run on options data.

### New user flow
```python
import optopsy as op

stocks = op.load_cached_stocks("SPY")
options = op.load_cached_options("SPY")

entry = op.signal_dates(stocks, op.rsi_below(threshold=30))
results = op.long_calls(options, entry_dates=entry)
```

## Test plan

- [x] All 1268 tests pass
- [x] Pre-commit hooks pass (ruff format, ruff check, ty, pytest, branch name)
- [x] Zero remaining references to `apply_signal` in codebase
- [x] Docs and samples updated to show new flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)