### PR TITLE
Fix noisy Postgres ALTER TABLE errors in DB init

### DIFF
--- a/optopsy/ui/app.py
+++ b/optopsy/ui/app.py
@@ -276,15 +276,25 @@ def _init_db_sync() -> None:
             # transaction as failed after any error).  Using separate
             # transactions avoids SAVEPOINTs, which are unreliable with
             # pysqlite's default transaction handling.
+            is_pg = sync_url.startswith("postgresql")
             for col, definition in [
                 ("defaultOpen", "INTEGER DEFAULT 0"),
                 ("waitForAnswer", "INTEGER"),
             ]:
                 try:
                     with engine.begin() as conn:
-                        conn.execute(
-                            text(f'ALTER TABLE steps ADD COLUMN "{col}" {definition}')
-                        )
+                        if is_pg:
+                            conn.execute(
+                                text(
+                                    f'ALTER TABLE steps ADD COLUMN IF NOT EXISTS "{col}" {definition}'
+                                )
+                            )
+                        else:
+                            conn.execute(
+                                text(
+                                    f'ALTER TABLE steps ADD COLUMN "{col}" {definition}'
+                                )
+                            )
                 except (OperationalError, ProgrammingError):
                     pass  # column already exists
 


### PR DESCRIPTION
Use ADD COLUMN IF NOT EXISTS for PostgreSQL to avoid
"column already exists" errors for defaultOpen and waitForAnswer
columns that are already in the CREATE TABLE definition.

https://claude.ai/code/session_014D8iBWkvdrS4G6PrPTG3YN